### PR TITLE
Fix five bugs, and make the gate that should have caught two of them run

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,10 @@ than the worker heartbeat quietly covering for a loop that never started), is
 the element under the middle of the stage really the canvas, does dragging
 rotate the globe, does a pinch zoom it, does a cancelled pinch strand the
 gesture, does the K–Pg link still appear in 1980 and harden in 1991, does a
-shared URL restore the view, can a hostile hash poison it. 41 checks, wired into
-`build.py`, exits non-zero.
+shared URL restore the view, can a hostile hash poison it, is a marker only as
+clickable as it is big, do the rival markers agree with the band they sit in, and
+does toggling the basemap reach the URL. 44 checks, wired into `build.py`,
+exits non-zero.
 
 It exists because this project lost an entire build to a boot failure that
 nothing detected: a legend swatch read the wrong palette key, `undefined` reached

--- a/artifact.html
+++ b/artifact.html
@@ -791,7 +791,10 @@ function readPalette() {
                    'land', 'land-edge', 'plate'])
     CSSV[k] = cs.getPropertyValue('--' + k).trim();
 }
-function subjColor(subjects) { return CSSV[subjects[0]] || CSSV.chalk_dim || '#888'; }
+/* The palette is keyed by the CSS custom-property name, so the dim-chalk
+   fallback is CSSV['chalk-dim']. CSSV.chalk_dim is never set, and reading it
+   sent every unknown subject to the hard-coded grey instead of the theme. */
+function subjColor(subjects) { return CSSV[subjects[0]] || CSSV['chalk-dim'] || '#888'; }
 
 function withAlpha(hex, a) {
   // Defensive: a missing palette key used to throw here, and the throw killed
@@ -1103,8 +1106,6 @@ function facts() { return FACTS || (FACTS = queryFacts(S)); }
 function epistemicCaption() {
   const F = facts();
   const kt = S.kt;
-  const chic = F.allEdges.find(e =>
-    e.edge.source === 'chicxulub_impact' && e.edge.target === 'kpg_extinction');
   const bits = [];
 
   if (kt < 1700) bits.push('The Earth has a history, but almost no one is counting it in years yet.');
@@ -1120,7 +1121,6 @@ function epistemicCaption() {
 
   const n = F.visible.length, d = F.disputedCount;
   bits.push(`${n} of ${Object.keys(R.referents).length} subjects visible, ${d} of them still disputed.`);
-  if (chic) bits.push(chic.superseded ? '' : '');
   return bits.filter(Boolean).join(' ');
 }
 
@@ -1766,9 +1766,13 @@ function drawGlobe(dt) {
       gx.fillStyle = withAlpha(col, it.dimmed ? 0.03 : 0.055); gx.fill();
     }
 
-    // A node pulled back only to carry an edge is a supporting player.
-    drawMarker(sx, sy, it.viaEdge ? Math.min(it.res.significance, 2) : it.res.significance,
-      col, st, {
+    // A node pulled back only to carry an edge is a supporting player. Its
+    // drawn size is the one everything else has to agree with: the hit target
+    // and the rolled-up count were sized from the full significance, so a
+    // recalled dot of radius 4.9 claimed a 16 px invisible target and stole
+    // hovers and clicks from whatever was drawn under it.
+    const sig = it.viaEdge ? Math.min(it.res.significance, 2) : it.res.significance;
+    drawMarker(sx, sy, sig, col, st, {
         selected: it.id === S.selection,
         dimmed: it.dimmed,
         disputed: it.res.disputed,
@@ -1778,10 +1782,10 @@ function drawGlobe(dt) {
     if (it.rolledUp) {
       gx.font = `600 9px ${'xt-mono'}, monospace`;
       gx.fillStyle = CSSV['chalk-dim'];
-      gx.fillText('+' + it.rolledUp, sx + markerRadius(it.res.significance) + 3, sy - 5);
+      gx.fillText('+' + it.rolledUp, sx + markerRadius(sig) + 3, sy - 5);
     }
 
-    HIT.push({ id: it.id, x: sx, y: sy, r: markerRadius(it.res.significance) + 7 });
+    HIT.push({ id: it.id, x: sx, y: sy, r: markerRadius(sig) + 7 });
 
     const strong = it.id === S.selection || it.id === S.hover;
     if (!it.dimmed && (strong || (it.res.significance >= 4 && !it.viaEdge)))
@@ -1937,7 +1941,12 @@ function drawFacts(sc, yTop, h) {
       cx2.moveTo(xw, y); cx2.lineTo(xy, y);
       cx2.strokeStyle = withAlpha(col, 0.35); cx2.stroke();
 
-      for (const alt of r.dated) {
+      /* pool, not dated: the markers sit inside the band, and the band is the
+         envelope of the claims competing for the DATE. Drawing every claim that
+         merely carries one puts hollow markers outside their own band and
+         overstates the disagreement - Chicxulub drew thirteen where six claims
+         actually rival each other. */
+      for (const alt of r.pool) {
         if (alt === r.winner) continue;
         const ax = sc.x(alt.claim.earth_time_start);
         if (ax < -10 || ax > CW + 10) continue;
@@ -3106,19 +3115,24 @@ elDetail.addEventListener('click', e => {
   elDetail.scrollTop = 0;
 });
 
+/* Both of these are in the hash, so both have to go through changed().
+   Setting needGlobe alone left the URL describing a view the page was no longer
+   showing, and the setting then arrived in the hash on the next unrelated
+   interaction - the same silent history rewrite src/76_url.js already fixed once
+   for the selection. */
 document.getElementById('btn-basemap').addEventListener('click', e => {
   S.basemap = S.basemap === 'satellite' ? 'chart' : 'satellite';
   const sat = S.basemap === 'satellite';
   e.currentTarget.setAttribute('aria-pressed', String(sat));
   e.currentTarget.textContent = sat ? 'Satellite' : 'Chart';
   document.getElementById('stage').classList.toggle('space', sat);
-  needGlobe = true;
+  changed();
 });
 
 document.getElementById('btn-plates').addEventListener('click', e => {
   S.showPlates = !S.showPlates;
   e.currentTarget.setAttribute('aria-pressed', String(S.showPlates));
-  needGlobe = true;
+  changed();
 });
 document.getElementById('btn-now').addEventListener('click', () => { stopReplay(); setKt(KT_MAX); });
 document.getElementById('btn-play').addEventListener('click', () => S.playing ? stopReplay() : startReplay());
@@ -3362,7 +3376,6 @@ function isAnimating() {
   if (Math.abs(S.spin.lam) > 0.008 || Math.abs(S.spin.phi) > 0.008) return true;
   if (S.playing || TW) return true;              // Replay, and the guided path
   return facts().edges.length > 0;               // arcs animate continuously
-  return false;
 }
 
 function onBeat() {

--- a/earth-x-time.html
+++ b/earth-x-time.html
@@ -798,7 +798,10 @@ function readPalette() {
                    'land', 'land-edge', 'plate'])
     CSSV[k] = cs.getPropertyValue('--' + k).trim();
 }
-function subjColor(subjects) { return CSSV[subjects[0]] || CSSV.chalk_dim || '#888'; }
+/* The palette is keyed by the CSS custom-property name, so the dim-chalk
+   fallback is CSSV['chalk-dim']. CSSV.chalk_dim is never set, and reading it
+   sent every unknown subject to the hard-coded grey instead of the theme. */
+function subjColor(subjects) { return CSSV[subjects[0]] || CSSV['chalk-dim'] || '#888'; }
 
 function withAlpha(hex, a) {
   // Defensive: a missing palette key used to throw here, and the throw killed
@@ -1110,8 +1113,6 @@ function facts() { return FACTS || (FACTS = queryFacts(S)); }
 function epistemicCaption() {
   const F = facts();
   const kt = S.kt;
-  const chic = F.allEdges.find(e =>
-    e.edge.source === 'chicxulub_impact' && e.edge.target === 'kpg_extinction');
   const bits = [];
 
   if (kt < 1700) bits.push('The Earth has a history, but almost no one is counting it in years yet.');
@@ -1127,7 +1128,6 @@ function epistemicCaption() {
 
   const n = F.visible.length, d = F.disputedCount;
   bits.push(`${n} of ${Object.keys(R.referents).length} subjects visible, ${d} of them still disputed.`);
-  if (chic) bits.push(chic.superseded ? '' : '');
   return bits.filter(Boolean).join(' ');
 }
 
@@ -1773,9 +1773,13 @@ function drawGlobe(dt) {
       gx.fillStyle = withAlpha(col, it.dimmed ? 0.03 : 0.055); gx.fill();
     }
 
-    // A node pulled back only to carry an edge is a supporting player.
-    drawMarker(sx, sy, it.viaEdge ? Math.min(it.res.significance, 2) : it.res.significance,
-      col, st, {
+    // A node pulled back only to carry an edge is a supporting player. Its
+    // drawn size is the one everything else has to agree with: the hit target
+    // and the rolled-up count were sized from the full significance, so a
+    // recalled dot of radius 4.9 claimed a 16 px invisible target and stole
+    // hovers and clicks from whatever was drawn under it.
+    const sig = it.viaEdge ? Math.min(it.res.significance, 2) : it.res.significance;
+    drawMarker(sx, sy, sig, col, st, {
         selected: it.id === S.selection,
         dimmed: it.dimmed,
         disputed: it.res.disputed,
@@ -1785,10 +1789,10 @@ function drawGlobe(dt) {
     if (it.rolledUp) {
       gx.font = `600 9px ${'xt-mono'}, monospace`;
       gx.fillStyle = CSSV['chalk-dim'];
-      gx.fillText('+' + it.rolledUp, sx + markerRadius(it.res.significance) + 3, sy - 5);
+      gx.fillText('+' + it.rolledUp, sx + markerRadius(sig) + 3, sy - 5);
     }
 
-    HIT.push({ id: it.id, x: sx, y: sy, r: markerRadius(it.res.significance) + 7 });
+    HIT.push({ id: it.id, x: sx, y: sy, r: markerRadius(sig) + 7 });
 
     const strong = it.id === S.selection || it.id === S.hover;
     if (!it.dimmed && (strong || (it.res.significance >= 4 && !it.viaEdge)))
@@ -1944,7 +1948,12 @@ function drawFacts(sc, yTop, h) {
       cx2.moveTo(xw, y); cx2.lineTo(xy, y);
       cx2.strokeStyle = withAlpha(col, 0.35); cx2.stroke();
 
-      for (const alt of r.dated) {
+      /* pool, not dated: the markers sit inside the band, and the band is the
+         envelope of the claims competing for the DATE. Drawing every claim that
+         merely carries one puts hollow markers outside their own band and
+         overstates the disagreement - Chicxulub drew thirteen where six claims
+         actually rival each other. */
+      for (const alt of r.pool) {
         if (alt === r.winner) continue;
         const ax = sc.x(alt.claim.earth_time_start);
         if (ax < -10 || ax > CW + 10) continue;
@@ -3113,19 +3122,24 @@ elDetail.addEventListener('click', e => {
   elDetail.scrollTop = 0;
 });
 
+/* Both of these are in the hash, so both have to go through changed().
+   Setting needGlobe alone left the URL describing a view the page was no longer
+   showing, and the setting then arrived in the hash on the next unrelated
+   interaction - the same silent history rewrite src/76_url.js already fixed once
+   for the selection. */
 document.getElementById('btn-basemap').addEventListener('click', e => {
   S.basemap = S.basemap === 'satellite' ? 'chart' : 'satellite';
   const sat = S.basemap === 'satellite';
   e.currentTarget.setAttribute('aria-pressed', String(sat));
   e.currentTarget.textContent = sat ? 'Satellite' : 'Chart';
   document.getElementById('stage').classList.toggle('space', sat);
-  needGlobe = true;
+  changed();
 });
 
 document.getElementById('btn-plates').addEventListener('click', e => {
   S.showPlates = !S.showPlates;
   e.currentTarget.setAttribute('aria-pressed', String(S.showPlates));
-  needGlobe = true;
+  changed();
 });
 document.getElementById('btn-now').addEventListener('click', () => { stopReplay(); setKt(KT_MAX); });
 document.getElementById('btn-play').addEventListener('click', () => S.playing ? stopReplay() : startReplay());
@@ -3369,7 +3383,6 @@ function isAnimating() {
   if (Math.abs(S.spin.lam) > 0.008 || Math.abs(S.spin.phi) > 0.008) return true;
   if (S.playing || TW) return true;              // Replay, and the guided path
   return facts().edges.length > 0;               // arcs animate continuously
-  return false;
 }
 
 function onBeat() {

--- a/index.html
+++ b/index.html
@@ -798,7 +798,10 @@ function readPalette() {
                    'land', 'land-edge', 'plate'])
     CSSV[k] = cs.getPropertyValue('--' + k).trim();
 }
-function subjColor(subjects) { return CSSV[subjects[0]] || CSSV.chalk_dim || '#888'; }
+/* The palette is keyed by the CSS custom-property name, so the dim-chalk
+   fallback is CSSV['chalk-dim']. CSSV.chalk_dim is never set, and reading it
+   sent every unknown subject to the hard-coded grey instead of the theme. */
+function subjColor(subjects) { return CSSV[subjects[0]] || CSSV['chalk-dim'] || '#888'; }
 
 function withAlpha(hex, a) {
   // Defensive: a missing palette key used to throw here, and the throw killed
@@ -1110,8 +1113,6 @@ function facts() { return FACTS || (FACTS = queryFacts(S)); }
 function epistemicCaption() {
   const F = facts();
   const kt = S.kt;
-  const chic = F.allEdges.find(e =>
-    e.edge.source === 'chicxulub_impact' && e.edge.target === 'kpg_extinction');
   const bits = [];
 
   if (kt < 1700) bits.push('The Earth has a history, but almost no one is counting it in years yet.');
@@ -1127,7 +1128,6 @@ function epistemicCaption() {
 
   const n = F.visible.length, d = F.disputedCount;
   bits.push(`${n} of ${Object.keys(R.referents).length} subjects visible, ${d} of them still disputed.`);
-  if (chic) bits.push(chic.superseded ? '' : '');
   return bits.filter(Boolean).join(' ');
 }
 
@@ -1773,9 +1773,13 @@ function drawGlobe(dt) {
       gx.fillStyle = withAlpha(col, it.dimmed ? 0.03 : 0.055); gx.fill();
     }
 
-    // A node pulled back only to carry an edge is a supporting player.
-    drawMarker(sx, sy, it.viaEdge ? Math.min(it.res.significance, 2) : it.res.significance,
-      col, st, {
+    // A node pulled back only to carry an edge is a supporting player. Its
+    // drawn size is the one everything else has to agree with: the hit target
+    // and the rolled-up count were sized from the full significance, so a
+    // recalled dot of radius 4.9 claimed a 16 px invisible target and stole
+    // hovers and clicks from whatever was drawn under it.
+    const sig = it.viaEdge ? Math.min(it.res.significance, 2) : it.res.significance;
+    drawMarker(sx, sy, sig, col, st, {
         selected: it.id === S.selection,
         dimmed: it.dimmed,
         disputed: it.res.disputed,
@@ -1785,10 +1789,10 @@ function drawGlobe(dt) {
     if (it.rolledUp) {
       gx.font = `600 9px ${'xt-mono'}, monospace`;
       gx.fillStyle = CSSV['chalk-dim'];
-      gx.fillText('+' + it.rolledUp, sx + markerRadius(it.res.significance) + 3, sy - 5);
+      gx.fillText('+' + it.rolledUp, sx + markerRadius(sig) + 3, sy - 5);
     }
 
-    HIT.push({ id: it.id, x: sx, y: sy, r: markerRadius(it.res.significance) + 7 });
+    HIT.push({ id: it.id, x: sx, y: sy, r: markerRadius(sig) + 7 });
 
     const strong = it.id === S.selection || it.id === S.hover;
     if (!it.dimmed && (strong || (it.res.significance >= 4 && !it.viaEdge)))
@@ -1944,7 +1948,12 @@ function drawFacts(sc, yTop, h) {
       cx2.moveTo(xw, y); cx2.lineTo(xy, y);
       cx2.strokeStyle = withAlpha(col, 0.35); cx2.stroke();
 
-      for (const alt of r.dated) {
+      /* pool, not dated: the markers sit inside the band, and the band is the
+         envelope of the claims competing for the DATE. Drawing every claim that
+         merely carries one puts hollow markers outside their own band and
+         overstates the disagreement - Chicxulub drew thirteen where six claims
+         actually rival each other. */
+      for (const alt of r.pool) {
         if (alt === r.winner) continue;
         const ax = sc.x(alt.claim.earth_time_start);
         if (ax < -10 || ax > CW + 10) continue;
@@ -3113,19 +3122,24 @@ elDetail.addEventListener('click', e => {
   elDetail.scrollTop = 0;
 });
 
+/* Both of these are in the hash, so both have to go through changed().
+   Setting needGlobe alone left the URL describing a view the page was no longer
+   showing, and the setting then arrived in the hash on the next unrelated
+   interaction - the same silent history rewrite src/76_url.js already fixed once
+   for the selection. */
 document.getElementById('btn-basemap').addEventListener('click', e => {
   S.basemap = S.basemap === 'satellite' ? 'chart' : 'satellite';
   const sat = S.basemap === 'satellite';
   e.currentTarget.setAttribute('aria-pressed', String(sat));
   e.currentTarget.textContent = sat ? 'Satellite' : 'Chart';
   document.getElementById('stage').classList.toggle('space', sat);
-  needGlobe = true;
+  changed();
 });
 
 document.getElementById('btn-plates').addEventListener('click', e => {
   S.showPlates = !S.showPlates;
   e.currentTarget.setAttribute('aria-pressed', String(S.showPlates));
-  needGlobe = true;
+  changed();
 });
 document.getElementById('btn-now').addEventListener('click', () => { stopReplay(); setKt(KT_MAX); });
 document.getElementById('btn-play').addEventListener('click', () => S.playing ? stopReplay() : startReplay());
@@ -3369,7 +3383,6 @@ function isAnimating() {
   if (Math.abs(S.spin.lam) > 0.008 || Math.abs(S.spin.phi) > 0.008) return true;
   if (S.playing || TW) return true;              // Replay, and the guided path
   return facts().edges.length > 0;               // arcs animate continuously
-  return false;
 }
 
 function onBeat() {

--- a/src/20_core.js
+++ b/src/20_core.js
@@ -210,7 +210,10 @@ function readPalette() {
                    'land', 'land-edge', 'plate'])
     CSSV[k] = cs.getPropertyValue('--' + k).trim();
 }
-function subjColor(subjects) { return CSSV[subjects[0]] || CSSV.chalk_dim || '#888'; }
+/* The palette is keyed by the CSS custom-property name, so the dim-chalk
+   fallback is CSSV['chalk-dim']. CSSV.chalk_dim is never set, and reading it
+   sent every unknown subject to the hard-coded grey instead of the theme. */
+function subjColor(subjects) { return CSSV[subjects[0]] || CSSV['chalk-dim'] || '#888'; }
 
 function withAlpha(hex, a) {
   // Defensive: a missing palette key used to throw here, and the throw killed

--- a/src/30_model.js
+++ b/src/30_model.js
@@ -254,8 +254,6 @@ function facts() { return FACTS || (FACTS = queryFacts(S)); }
 function epistemicCaption() {
   const F = facts();
   const kt = S.kt;
-  const chic = F.allEdges.find(e =>
-    e.edge.source === 'chicxulub_impact' && e.edge.target === 'kpg_extinction');
   const bits = [];
 
   if (kt < 1700) bits.push('The Earth has a history, but almost no one is counting it in years yet.');
@@ -271,6 +269,5 @@ function epistemicCaption() {
 
   const n = F.visible.length, d = F.disputedCount;
   bits.push(`${n} of ${Object.keys(R.referents).length} subjects visible, ${d} of them still disputed.`);
-  if (chic) bits.push(chic.superseded ? '' : '');
   return bits.filter(Boolean).join(' ');
 }

--- a/src/40_globe.js
+++ b/src/40_globe.js
@@ -640,9 +640,13 @@ function drawGlobe(dt) {
       gx.fillStyle = withAlpha(col, it.dimmed ? 0.03 : 0.055); gx.fill();
     }
 
-    // A node pulled back only to carry an edge is a supporting player.
-    drawMarker(sx, sy, it.viaEdge ? Math.min(it.res.significance, 2) : it.res.significance,
-      col, st, {
+    // A node pulled back only to carry an edge is a supporting player. Its
+    // drawn size is the one everything else has to agree with: the hit target
+    // and the rolled-up count were sized from the full significance, so a
+    // recalled dot of radius 4.9 claimed a 16 px invisible target and stole
+    // hovers and clicks from whatever was drawn under it.
+    const sig = it.viaEdge ? Math.min(it.res.significance, 2) : it.res.significance;
+    drawMarker(sx, sy, sig, col, st, {
         selected: it.id === S.selection,
         dimmed: it.dimmed,
         disputed: it.res.disputed,
@@ -652,10 +656,10 @@ function drawGlobe(dt) {
     if (it.rolledUp) {
       gx.font = `600 9px ${'xt-mono'}, monospace`;
       gx.fillStyle = CSSV['chalk-dim'];
-      gx.fillText('+' + it.rolledUp, sx + markerRadius(it.res.significance) + 3, sy - 5);
+      gx.fillText('+' + it.rolledUp, sx + markerRadius(sig) + 3, sy - 5);
     }
 
-    HIT.push({ id: it.id, x: sx, y: sy, r: markerRadius(it.res.significance) + 7 });
+    HIT.push({ id: it.id, x: sx, y: sy, r: markerRadius(sig) + 7 });
 
     const strong = it.id === S.selection || it.id === S.hover;
     if (!it.dimmed && (strong || (it.res.significance >= 4 && !it.viaEdge)))

--- a/src/50_chron.js
+++ b/src/50_chron.js
@@ -144,7 +144,12 @@ function drawFacts(sc, yTop, h) {
       cx2.moveTo(xw, y); cx2.lineTo(xy, y);
       cx2.strokeStyle = withAlpha(col, 0.35); cx2.stroke();
 
-      for (const alt of r.dated) {
+      /* pool, not dated: the markers sit inside the band, and the band is the
+         envelope of the claims competing for the DATE. Drawing every claim that
+         merely carries one puts hollow markers outside their own band and
+         overstates the disagreement - Chicxulub drew thirteen where six claims
+         actually rival each other. */
+      for (const alt of r.pool) {
         if (alt === r.winner) continue;
         const ax = sc.x(alt.claim.earth_time_start);
         if (ax < -10 || ax > CW + 10) continue;

--- a/src/80_boot.js
+++ b/src/80_boot.js
@@ -357,19 +357,24 @@ elDetail.addEventListener('click', e => {
   elDetail.scrollTop = 0;
 });
 
+/* Both of these are in the hash, so both have to go through changed().
+   Setting needGlobe alone left the URL describing a view the page was no longer
+   showing, and the setting then arrived in the hash on the next unrelated
+   interaction - the same silent history rewrite src/76_url.js already fixed once
+   for the selection. */
 document.getElementById('btn-basemap').addEventListener('click', e => {
   S.basemap = S.basemap === 'satellite' ? 'chart' : 'satellite';
   const sat = S.basemap === 'satellite';
   e.currentTarget.setAttribute('aria-pressed', String(sat));
   e.currentTarget.textContent = sat ? 'Satellite' : 'Chart';
   document.getElementById('stage').classList.toggle('space', sat);
-  needGlobe = true;
+  changed();
 });
 
 document.getElementById('btn-plates').addEventListener('click', e => {
   S.showPlates = !S.showPlates;
   e.currentTarget.setAttribute('aria-pressed', String(S.showPlates));
-  needGlobe = true;
+  changed();
 });
 document.getElementById('btn-now').addEventListener('click', () => { stopReplay(); setKt(KT_MAX); });
 document.getElementById('btn-play').addEventListener('click', () => S.playing ? stopReplay() : startReplay());
@@ -613,7 +618,6 @@ function isAnimating() {
   if (Math.abs(S.spin.lam) > 0.008 || Math.abs(S.spin.phi) > 0.008) return true;
   if (S.playing || TW) return true;              // Replay, and the guided path
   return facts().edges.length > 0;               // arcs animate continuously
-  return false;
 }
 
 function onBeat() {

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -189,9 +189,8 @@ def run(url, headed, report):
         })""")
         report.check("legend swatches are styled", all(s and s != "MISSING" for s in sw),
                      json.dumps(sw)[:120])
-        report.check("subject chips rendered",
-                     page.evaluate("document.getElementById('subjects').children.length") == 6,
-                     f"{page.evaluate('document.getElementById(\"subjects\").children.length')} chips")
+        chips = page.evaluate("document.getElementById('subjects').children.length")
+        report.check("subject chips rendered", chips == 6, f"{chips} chips")
 
         # --------------------------------------------------- 5. does it respond
         lam0 = page.evaluate("S.rot.lam")
@@ -330,6 +329,75 @@ def run(url, headed, report):
                          txt[:60].replace("\n", " "))
             page.keyboard.press("Escape")
             page.wait_for_timeout(120)
+
+        # ------------------------------- 7b. what is drawn is what is clickable
+        # A node recalled only to carry an edge is drawn small (significance
+        # capped at 2). Its hit target was sized from the UNCAPPED significance,
+        # so a 4.9 px dot claimed a 16 px invisible circle and stole hovers and
+        # clicks from whatever was under it.
+        page.evaluate("S.selection = null; markAll(); renderNow();")
+        page.wait_for_timeout(150)
+        mismatch = page.evaluate("""() => {
+          const bad = [];
+          for (const it of facts().visible) {
+            if (!it.viaEdge) continue;
+            // planet-wide facts ride the horizon instead of being markers, and
+            // carry their own fixed-radius hit target; they are not this check.
+            const h = HIT.find(x => x.id === it.id && !x.global);
+            if (!h) continue;
+            const drawn = markerRadius(Math.min(it.res.significance, 2)) + 7;
+            if (Math.abs(h.r - drawn) > 0.01) bad.push({ id: it.id, hit: h.r, drawn });
+          }
+          return bad;
+        }""")
+        report.check("edge-recalled markers are only as clickable as they are big",
+                     mismatch == [], json.dumps(mismatch)[:160])
+
+        # --------------------------- 7c. the rival markers agree with their band
+        # The band is the envelope of the claims competing for the DATE (res.pool).
+        # The hollow markers inside it were drawn from res.dated - every live claim
+        # carrying any date at all - so markers landed outside their own band and
+        # overstated the disagreement. Radius 3 is the alt-marker radius and
+        # nothing else in drawFacts uses it (a winner is 2.5 + significance*0.85,
+        # never below 3.35).
+        marks = page.evaluate("""() => {
+          const ctx = document.getElementById('chroncv').getContext('2d');
+          const real = ctx.arc.bind(ctx);
+          let n = 0;
+          ctx.arc = function (x, y, r, a, b, c) { if (r === 3) n++; return real(x, y, r, a, b, c); };
+          needChron = true; drawChron();
+          ctx.arc = real;
+          let pool = 0, dated = 0;
+          for (const it of facts().visible) {
+            const r = it.res;
+            if (!(r.disputed || S.resolver === 'spread')) continue;
+            pool += r.pool.filter(l => l !== r.winner).length;
+            dated += r.dated.filter(l => l !== r.winner).length;
+          }
+          return { drawn: n, pool, dated };
+        }""")
+        # Off-window markers are skipped, so drawn can only ever be <= the pool.
+        # What must never happen is drawing more than the pool has in it.
+        report.check("rival markers come from the claims competing for the date",
+                     marks["drawn"] <= marks["pool"] and marks["pool"] < marks["dated"],
+                     json.dumps(marks))
+
+        # ------------------------------------------ 7d. every setting has a URL
+        # encodeHash carries the basemap and the plate overlay, but the two
+        # buttons only marked the globe dirty, so the toggle never wrote the hash
+        # and the setting then arrived in it on the next unrelated interaction.
+        page.evaluate("writeHash(true)")
+        before = page.evaluate("location.hash")
+        page.click("#btn-basemap")
+        page.click("#btn-plates")
+        page.wait_for_timeout(600)
+        after = page.evaluate("location.hash")
+        report.check("toggling the basemap and the plates reaches the URL",
+                     "b=chart" in after and "p=0" in after,
+                     f"{before[:40]} -> {after[:70]}")
+        page.click("#btn-basemap")
+        page.click("#btn-plates")
+        page.wait_for_timeout(600)
 
         # -------------------------------------------------------- 8. URL state
         st = page.evaluate("typeof writeHash === 'function'")


### PR DESCRIPTION
Wave 1 of a bug audit. Five confirmed bugs, each reproduced in a real browser before it was touched, and three new smoke checks that each fail against the bug reintroduced.

Closes #1, closes #2, closes #3, closes #4, closes #5.

## The gate first

`tools/smoke_test.py` did not parse on any Python before 3.12 — a backslash inside an f-string expression, which PEP 701 only permitted in 3.12. The repository declares no minimum Python version and this container runs 3.11.

So the 41 checks the README calls the primary gate never ran here, in either of the two states available:

- playwright absent → `build.py` prints `(skipping smoke test: ...)` and the build passes;
- playwright present → the file dies at import and `build.py` exits `FATAL: the built page does not work`, which is not what went wrong.

With the `evaluate` hoisted out of the f-string, the suite runs. Two of the four bugs below are things it can now assert.

## The four it can now speak for

**The Satellite and Plates buttons never wrote the URL.** `encodeHash` serialises both (`b=chart`, `p=0`) and `readHash` restores both, but the click handlers only set `needGlobe = true` — never `changed()`, which is what calls `writeHash()`. Measured:

```
before:  #k=2026&t=0_4600000000&r=30.0,12.0&z=0.86
toggle Satellite -> Chart, Plates off
after:   #k=2026&t=0_4600000000&r=30.0,12.0&z=0.86      <- unchanged
```

A shared link lost the view, and the setting then arrived in the hash on the next unrelated interaction — the same silent history rewrite `src/76_url.js` documents having already fixed once for the selection.

**The timeline drew its rival markers from the wrong set.** `resolve()` separates `dated` (every live claim carrying a date) from `pool` (the claims actually competing for the date). The band, the winner, `alternatives` and the detail panel all use `pool`; `drawFacts` drew the hollow markers *inside that band* from `dated`. The markers therefore disagreed with the band they sat in, and were the wider of the two — overstating the disagreement in exactly the way the README's first rule exists to prevent. 22 disputed referents were affected; Chicxulub drew 13 markers where 6 claims rival each other, and the origin of life drew 7 against the 5 the README promises.

**Edge-recalled markers were more clickable than they are big.** A node pulled back only to carry an edge is drawn with its significance capped at 2, but the hit target and the `+n` rolled-up label were both sized from the uncapped value. A dot of radius 4.9 claimed a 16.2 px invisible circle, and 14 such nodes sit on the default view — enough to take hovers and clicks from whatever is drawn underneath.

**Three dead paths.** `subjColor` fell back to `CSSV.chalk_dim`, which is never set — the palette is keyed by the CSS custom-property name, `CSSV['chalk-dim']` — so an unknown subject reached a hard-coded `#888` instead of the theme (`subjColor(['nope'])` returned `#888` while `CSSV['chalk-dim']` was `#4E656D`). `epistemicCaption` looked up the Chicxulub edge on every panel render and then pushed the empty string on both arms of the conditional. `isAnimating` had a `return` after a `return`.

## Verification

```
python3 tools/validate_graph.py    ERRORS (0)
python3 tools/build.py             44/44 checks passed
```

Each new check was confirmed against a deliberately reintroduced bug, per the file's own standard:

```
[FAIL] edge-recalled markers are only as clickable as they are big
       [{"id":"first_primates","hit":14.2,"drawn":11.9}, ...]
[FAIL] rival markers come from the claims competing for the date
       {"drawn":31,"pool":28,"dated":45}
[FAIL] toggling the basemap and the plates reaches the URL
41/44 checks passed
```

and back to 44/44 with the fixes restored. `tools/check_no_local_paths.py --all` is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_