### PR TITLE
Make the phone build reachable, and put a phone in the smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,14 @@ rotate the globe, does a pinch zoom it, does a cancelled pinch strand the
 gesture, does the K–Pg link still appear in 1980 and harden in 1991, does a
 shared URL restore the view, can a hostile hash poison it, is a marker only as
 clickable as it is big, do the rival markers agree with the band they sit in, and
-does toggling the basemap reach the URL. 44 checks, wired into `build.py`,
-exits non-zero.
+does toggling the basemap reach the URL.
+
+Then it opens a second context at 390x844 with real touch and asks the phone
+build the questions the desktop one cannot: can a finger reach every control on
+the stage, does tapping a marker put its panel where you can see it, does
+choosing a search result fly a globe that is on screen, is the globe's focus
+ring inside its own clipping box. 51 checks, wired into `build.py`, exits
+non-zero.
 
 It exists because this project lost an entire build to a boot failure that
 nothing detected: a legend swatch read the wrong palette key, `undefined` reached
@@ -189,11 +195,17 @@ and live by 1985. It exits non-zero on any of those.
   endpoint is a referent that does not exist yet. They render in the panel and
   say nothing to the graph.
 - **Not React.** See below.
-- **A UX review found twelve more, none of them implemented.** The worst is that
-  `Guided path` renders entirely off the left edge on a phone, which makes the tour
-  unreachable on every phone — it has no other entry point. See
-  [`docs/ux-review-2026-08-03.md`](docs/ux-review-2026-08-03.md), which covers this
-  site and its sibling together.
+- **A UX review found twelve items; item 1 and the globe half of item 10 are
+  done, the rest are not.** The phone blockers are fixed — the stage control
+  strip no longer runs off the left edge (`Guided path` was entirely off-screen,
+  and it is the tour's only entry point), a tap on a marker now scrolls its
+  panel into view, a chosen search result no longer flies a globe that is above
+  the viewport, and the globe's focus ring is painted inside its own clipping
+  box instead of being clipped away. All four are asserted by the phone section
+  of the smoke test. Still open: the scroll-versus-rotate conflict on touch,
+  light-mode contrast on the stage overlays, `goTo()` bypassing `chooseResult`'s
+  gating, and the rest. See [`docs/ux-review-2026-08-03.md`](docs/ux-review-2026-08-03.md),
+  which covers this site and its sibling together.
 
 ## Two deliberate departures
 

--- a/artifact.html
+++ b/artifact.html
@@ -327,6 +327,11 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 
 /* ============================================================ STAGE */
 #globe { display: block; width: 100%; height: 100%; touch-action: none; cursor: grab; }
+/* The globe is exactly the size of .stage, and .stage is overflow:hidden, so the
+   shared :focus-visible ring — painted 2px OUTSIDE the border box — is clipped
+   away completely. On a role="application" element that swallows the arrow keys,
+   that leaves a keyboard user with no sign of where focus is. Paint it inside. */
+#globe:focus-visible { outline: none; box-shadow: inset 0 0 0 2px var(--cyanotype); }
 #globe.dragging { cursor: grabbing; }
 .stage-tl { position: absolute; top: 12px; left: 14px; pointer-events: none; max-width: 60%; }
 .as-of {
@@ -435,6 +440,17 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 }
 @media (max-width: 860px) {
   body { overflow: auto; }
+  /* The strip is shrink-to-fit anchored right, inside an overflow:hidden stage,
+     so as the stage narrows it grows off the LEFT edge and is clipped: at 390px
+     "Guided path" spans -64 to -1, and #btn-tour is the only entry point the
+     tour has. Span the stage and scroll instead — and start at flex-start, not
+     flex-end, because content overflowing the START edge of a flex scroll
+     container cannot be scrolled to in Chromium or WebKit. */
+  .stage-tr { left: 12px; right: 12px; justify-content: flex-start;
+    overflow-x: auto; overscroll-behavior-x: contain; scrollbar-width: none; }
+  .stage-tr::-webkit-scrollbar { display: none; }
+  .stage-tr .iconbtn { white-space: nowrap; flex: none; }
+  .stage-tl { top: 52px; }          /* the strip now owns the top line */
   .app { grid-template-columns: minmax(0,1fr) var(--rail-w); grid-template-rows: 46vh auto auto; height: auto; min-height: 100vh; min-height: 100dvh; }
   .stage { grid-column: 1; grid-row: 1; }
   .krail { grid-column: 2; grid-row: 1 / span 2; }
@@ -2546,9 +2562,18 @@ function chooseResult(id) {
   const t1 = res && isFinite(res.oldest)
     ? Math.max(2000, Math.min(T_MAX, res.oldest * 1.7))
     : S.win.t1;
-  flyTo({ id, kt, win: [0, t1] });
   closeResults();
   elSearch.blur();
+  /* On a phone the search box is in grid row 3 and the globe is row 1, so
+     choosing a result tweened the globe for 1.1s about 400px above the viewport.
+     Bring the stage back first. A no-op on desktop, where the body does not
+     scroll and the stage is always at the top. */
+  const stage = document.getElementById('stage');
+  if (stage && stage.getBoundingClientRect().top < 0) {
+    try { stage.scrollIntoView({ block: 'start', behavior: RM.matches ? 'auto' : 'smooth' }); }
+    catch (_) { stage.scrollIntoView(true); }
+  }
+  flyTo({ id, kt, win: [0, t1] });
 }
 
 let searchTimer = null;
@@ -2778,7 +2803,23 @@ function setWindow(t0, t1) {
   S.win.t0 = a; S.win.t1 = b;
   changed();
 }
-function setSelection(id) { S.selection = id; changed(); }
+/* Where the selection came from is an argument, not something to infer. Under a
+   coarse pointer the detail panel is in grid row 3, roughly 1170px below a 46vh
+   stage, and the tooltip never fires on touch — it lives after the drag branch
+   returns — so a tap on a marker changes nothing the tapper can see. Only a
+   selection made ON a canvas scrolls the panel up: Escape passes null, a
+   data-goto hop is already inside the panel, and the guided path is driving the
+   stage itself. */
+const COARSE = matchMedia('(pointer:coarse)');
+function setSelection(id, opts) {
+  S.selection = id;
+  changed();
+  if (id && opts && opts.fromCanvas && COARSE.matches && elDetail) {
+    try {
+      elDetail.scrollIntoView({ block: 'start', behavior: RM.matches ? 'auto' : 'smooth' });
+    } catch (_) { elDetail.scrollIntoView(true); }
+  }
+}
 
 /* ------------------------------------------------------------------- globe */
 let gDrag = null, gMoved = 0;
@@ -2913,7 +2954,7 @@ function endGlobeDrag(e) {
       const d = Math.hypot(h.x - mx, h.y - my);
       if (d < h.r && d < bd) { bd = d; best = h; }
     }
-    setSelection(best ? best.id : null);
+    setSelection(best ? best.id : null, { fromCanvas: true });
   }
 }
 /* Lifting a finger mid-pinch must not end the gesture, and must not be read as a
@@ -3021,7 +3062,8 @@ ccv.addEventListener('pointermove', e => {
 });
 
 ccv.addEventListener('pointerup', e => {
-  if (cDrag && cDrag.mode === 'click') setSelection(cDrag.id === S.selection ? null : cDrag.id);
+  if (cDrag && cDrag.mode === 'click')
+    setSelection(cDrag.id === S.selection ? null : cDrag.id, { fromCanvas: true });
   else if (cDrag && cDrag.mode === 'pan' && cDrag.moved < 2) {
     const sc = SCALE || chronScale();
     S.cursor = Math.max(0, Math.min(T_MAX, sc.t(chronPos(e).x)));

--- a/earth-x-time.html
+++ b/earth-x-time.html
@@ -332,6 +332,11 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 
 /* ============================================================ STAGE */
 #globe { display: block; width: 100%; height: 100%; touch-action: none; cursor: grab; }
+/* The globe is exactly the size of .stage, and .stage is overflow:hidden, so the
+   shared :focus-visible ring — painted 2px OUTSIDE the border box — is clipped
+   away completely. On a role="application" element that swallows the arrow keys,
+   that leaves a keyboard user with no sign of where focus is. Paint it inside. */
+#globe:focus-visible { outline: none; box-shadow: inset 0 0 0 2px var(--cyanotype); }
 #globe.dragging { cursor: grabbing; }
 .stage-tl { position: absolute; top: 12px; left: 14px; pointer-events: none; max-width: 60%; }
 .as-of {
@@ -440,6 +445,17 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 }
 @media (max-width: 860px) {
   body { overflow: auto; }
+  /* The strip is shrink-to-fit anchored right, inside an overflow:hidden stage,
+     so as the stage narrows it grows off the LEFT edge and is clipped: at 390px
+     "Guided path" spans -64 to -1, and #btn-tour is the only entry point the
+     tour has. Span the stage and scroll instead — and start at flex-start, not
+     flex-end, because content overflowing the START edge of a flex scroll
+     container cannot be scrolled to in Chromium or WebKit. */
+  .stage-tr { left: 12px; right: 12px; justify-content: flex-start;
+    overflow-x: auto; overscroll-behavior-x: contain; scrollbar-width: none; }
+  .stage-tr::-webkit-scrollbar { display: none; }
+  .stage-tr .iconbtn { white-space: nowrap; flex: none; }
+  .stage-tl { top: 52px; }          /* the strip now owns the top line */
   .app { grid-template-columns: minmax(0,1fr) var(--rail-w); grid-template-rows: 46vh auto auto; height: auto; min-height: 100vh; min-height: 100dvh; }
   .stage { grid-column: 1; grid-row: 1; }
   .krail { grid-column: 2; grid-row: 1 / span 2; }
@@ -2553,9 +2569,18 @@ function chooseResult(id) {
   const t1 = res && isFinite(res.oldest)
     ? Math.max(2000, Math.min(T_MAX, res.oldest * 1.7))
     : S.win.t1;
-  flyTo({ id, kt, win: [0, t1] });
   closeResults();
   elSearch.blur();
+  /* On a phone the search box is in grid row 3 and the globe is row 1, so
+     choosing a result tweened the globe for 1.1s about 400px above the viewport.
+     Bring the stage back first. A no-op on desktop, where the body does not
+     scroll and the stage is always at the top. */
+  const stage = document.getElementById('stage');
+  if (stage && stage.getBoundingClientRect().top < 0) {
+    try { stage.scrollIntoView({ block: 'start', behavior: RM.matches ? 'auto' : 'smooth' }); }
+    catch (_) { stage.scrollIntoView(true); }
+  }
+  flyTo({ id, kt, win: [0, t1] });
 }
 
 let searchTimer = null;
@@ -2785,7 +2810,23 @@ function setWindow(t0, t1) {
   S.win.t0 = a; S.win.t1 = b;
   changed();
 }
-function setSelection(id) { S.selection = id; changed(); }
+/* Where the selection came from is an argument, not something to infer. Under a
+   coarse pointer the detail panel is in grid row 3, roughly 1170px below a 46vh
+   stage, and the tooltip never fires on touch — it lives after the drag branch
+   returns — so a tap on a marker changes nothing the tapper can see. Only a
+   selection made ON a canvas scrolls the panel up: Escape passes null, a
+   data-goto hop is already inside the panel, and the guided path is driving the
+   stage itself. */
+const COARSE = matchMedia('(pointer:coarse)');
+function setSelection(id, opts) {
+  S.selection = id;
+  changed();
+  if (id && opts && opts.fromCanvas && COARSE.matches && elDetail) {
+    try {
+      elDetail.scrollIntoView({ block: 'start', behavior: RM.matches ? 'auto' : 'smooth' });
+    } catch (_) { elDetail.scrollIntoView(true); }
+  }
+}
 
 /* ------------------------------------------------------------------- globe */
 let gDrag = null, gMoved = 0;
@@ -2920,7 +2961,7 @@ function endGlobeDrag(e) {
       const d = Math.hypot(h.x - mx, h.y - my);
       if (d < h.r && d < bd) { bd = d; best = h; }
     }
-    setSelection(best ? best.id : null);
+    setSelection(best ? best.id : null, { fromCanvas: true });
   }
 }
 /* Lifting a finger mid-pinch must not end the gesture, and must not be read as a
@@ -3028,7 +3069,8 @@ ccv.addEventListener('pointermove', e => {
 });
 
 ccv.addEventListener('pointerup', e => {
-  if (cDrag && cDrag.mode === 'click') setSelection(cDrag.id === S.selection ? null : cDrag.id);
+  if (cDrag && cDrag.mode === 'click')
+    setSelection(cDrag.id === S.selection ? null : cDrag.id, { fromCanvas: true });
   else if (cDrag && cDrag.mode === 'pan' && cDrag.moved < 2) {
     const sc = SCALE || chronScale();
     S.cursor = Math.max(0, Math.min(T_MAX, sc.t(chronPos(e).x)));

--- a/index.html
+++ b/index.html
@@ -332,6 +332,11 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 
 /* ============================================================ STAGE */
 #globe { display: block; width: 100%; height: 100%; touch-action: none; cursor: grab; }
+/* The globe is exactly the size of .stage, and .stage is overflow:hidden, so the
+   shared :focus-visible ring — painted 2px OUTSIDE the border box — is clipped
+   away completely. On a role="application" element that swallows the arrow keys,
+   that leaves a keyboard user with no sign of where focus is. Paint it inside. */
+#globe:focus-visible { outline: none; box-shadow: inset 0 0 0 2px var(--cyanotype); }
 #globe.dragging { cursor: grabbing; }
 .stage-tl { position: absolute; top: 12px; left: 14px; pointer-events: none; max-width: 60%; }
 .as-of {
@@ -440,6 +445,17 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 }
 @media (max-width: 860px) {
   body { overflow: auto; }
+  /* The strip is shrink-to-fit anchored right, inside an overflow:hidden stage,
+     so as the stage narrows it grows off the LEFT edge and is clipped: at 390px
+     "Guided path" spans -64 to -1, and #btn-tour is the only entry point the
+     tour has. Span the stage and scroll instead — and start at flex-start, not
+     flex-end, because content overflowing the START edge of a flex scroll
+     container cannot be scrolled to in Chromium or WebKit. */
+  .stage-tr { left: 12px; right: 12px; justify-content: flex-start;
+    overflow-x: auto; overscroll-behavior-x: contain; scrollbar-width: none; }
+  .stage-tr::-webkit-scrollbar { display: none; }
+  .stage-tr .iconbtn { white-space: nowrap; flex: none; }
+  .stage-tl { top: 52px; }          /* the strip now owns the top line */
   .app { grid-template-columns: minmax(0,1fr) var(--rail-w); grid-template-rows: 46vh auto auto; height: auto; min-height: 100vh; min-height: 100dvh; }
   .stage { grid-column: 1; grid-row: 1; }
   .krail { grid-column: 2; grid-row: 1 / span 2; }
@@ -2553,9 +2569,18 @@ function chooseResult(id) {
   const t1 = res && isFinite(res.oldest)
     ? Math.max(2000, Math.min(T_MAX, res.oldest * 1.7))
     : S.win.t1;
-  flyTo({ id, kt, win: [0, t1] });
   closeResults();
   elSearch.blur();
+  /* On a phone the search box is in grid row 3 and the globe is row 1, so
+     choosing a result tweened the globe for 1.1s about 400px above the viewport.
+     Bring the stage back first. A no-op on desktop, where the body does not
+     scroll and the stage is always at the top. */
+  const stage = document.getElementById('stage');
+  if (stage && stage.getBoundingClientRect().top < 0) {
+    try { stage.scrollIntoView({ block: 'start', behavior: RM.matches ? 'auto' : 'smooth' }); }
+    catch (_) { stage.scrollIntoView(true); }
+  }
+  flyTo({ id, kt, win: [0, t1] });
 }
 
 let searchTimer = null;
@@ -2785,7 +2810,23 @@ function setWindow(t0, t1) {
   S.win.t0 = a; S.win.t1 = b;
   changed();
 }
-function setSelection(id) { S.selection = id; changed(); }
+/* Where the selection came from is an argument, not something to infer. Under a
+   coarse pointer the detail panel is in grid row 3, roughly 1170px below a 46vh
+   stage, and the tooltip never fires on touch — it lives after the drag branch
+   returns — so a tap on a marker changes nothing the tapper can see. Only a
+   selection made ON a canvas scrolls the panel up: Escape passes null, a
+   data-goto hop is already inside the panel, and the guided path is driving the
+   stage itself. */
+const COARSE = matchMedia('(pointer:coarse)');
+function setSelection(id, opts) {
+  S.selection = id;
+  changed();
+  if (id && opts && opts.fromCanvas && COARSE.matches && elDetail) {
+    try {
+      elDetail.scrollIntoView({ block: 'start', behavior: RM.matches ? 'auto' : 'smooth' });
+    } catch (_) { elDetail.scrollIntoView(true); }
+  }
+}
 
 /* ------------------------------------------------------------------- globe */
 let gDrag = null, gMoved = 0;
@@ -2920,7 +2961,7 @@ function endGlobeDrag(e) {
       const d = Math.hypot(h.x - mx, h.y - my);
       if (d < h.r && d < bd) { bd = d; best = h; }
     }
-    setSelection(best ? best.id : null);
+    setSelection(best ? best.id : null, { fromCanvas: true });
   }
 }
 /* Lifting a finger mid-pinch must not end the gesture, and must not be read as a
@@ -3028,7 +3069,8 @@ ccv.addEventListener('pointermove', e => {
 });
 
 ccv.addEventListener('pointerup', e => {
-  if (cDrag && cDrag.mode === 'click') setSelection(cDrag.id === S.selection ? null : cDrag.id);
+  if (cDrag && cDrag.mode === 'click')
+    setSelection(cDrag.id === S.selection ? null : cDrag.id, { fromCanvas: true });
   else if (cDrag && cDrag.mode === 'pan' && cDrag.moved < 2) {
     const sc = SCALE || chronScale();
     S.cursor = Math.max(0, Math.min(T_MAX, sc.t(chronPos(e).x)));

--- a/src/00_head.html
+++ b/src/00_head.html
@@ -325,6 +325,11 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 
 /* ============================================================ STAGE */
 #globe { display: block; width: 100%; height: 100%; touch-action: none; cursor: grab; }
+/* The globe is exactly the size of .stage, and .stage is overflow:hidden, so the
+   shared :focus-visible ring — painted 2px OUTSIDE the border box — is clipped
+   away completely. On a role="application" element that swallows the arrow keys,
+   that leaves a keyboard user with no sign of where focus is. Paint it inside. */
+#globe:focus-visible { outline: none; box-shadow: inset 0 0 0 2px var(--cyanotype); }
 #globe.dragging { cursor: grabbing; }
 .stage-tl { position: absolute; top: 12px; left: 14px; pointer-events: none; max-width: 60%; }
 .as-of {
@@ -433,6 +438,17 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 }
 @media (max-width: 860px) {
   body { overflow: auto; }
+  /* The strip is shrink-to-fit anchored right, inside an overflow:hidden stage,
+     so as the stage narrows it grows off the LEFT edge and is clipped: at 390px
+     "Guided path" spans -64 to -1, and #btn-tour is the only entry point the
+     tour has. Span the stage and scroll instead — and start at flex-start, not
+     flex-end, because content overflowing the START edge of a flex scroll
+     container cannot be scrolled to in Chromium or WebKit. */
+  .stage-tr { left: 12px; right: 12px; justify-content: flex-start;
+    overflow-x: auto; overscroll-behavior-x: contain; scrollbar-width: none; }
+  .stage-tr::-webkit-scrollbar { display: none; }
+  .stage-tr .iconbtn { white-space: nowrap; flex: none; }
+  .stage-tl { top: 52px; }          /* the strip now owns the top line */
   .app { grid-template-columns: minmax(0,1fr) var(--rail-w); grid-template-rows: 46vh auto auto; height: auto; min-height: 100vh; min-height: 100dvh; }
   .stage { grid-column: 1; grid-row: 1; }
   .krail { grid-column: 2; grid-row: 1 / span 2; }

--- a/src/75_search.js
+++ b/src/75_search.js
@@ -114,9 +114,18 @@ function chooseResult(id) {
   const t1 = res && isFinite(res.oldest)
     ? Math.max(2000, Math.min(T_MAX, res.oldest * 1.7))
     : S.win.t1;
-  flyTo({ id, kt, win: [0, t1] });
   closeResults();
   elSearch.blur();
+  /* On a phone the search box is in grid row 3 and the globe is row 1, so
+     choosing a result tweened the globe for 1.1s about 400px above the viewport.
+     Bring the stage back first. A no-op on desktop, where the body does not
+     scroll and the stage is always at the top. */
+  const stage = document.getElementById('stage');
+  if (stage && stage.getBoundingClientRect().top < 0) {
+    try { stage.scrollIntoView({ block: 'start', behavior: RM.matches ? 'auto' : 'smooth' }); }
+    catch (_) { stage.scrollIntoView(true); }
+  }
+  flyTo({ id, kt, win: [0, t1] });
 }
 
 let searchTimer = null;

--- a/src/80_boot.js
+++ b/src/80_boot.js
@@ -20,7 +20,23 @@ function setWindow(t0, t1) {
   S.win.t0 = a; S.win.t1 = b;
   changed();
 }
-function setSelection(id) { S.selection = id; changed(); }
+/* Where the selection came from is an argument, not something to infer. Under a
+   coarse pointer the detail panel is in grid row 3, roughly 1170px below a 46vh
+   stage, and the tooltip never fires on touch — it lives after the drag branch
+   returns — so a tap on a marker changes nothing the tapper can see. Only a
+   selection made ON a canvas scrolls the panel up: Escape passes null, a
+   data-goto hop is already inside the panel, and the guided path is driving the
+   stage itself. */
+const COARSE = matchMedia('(pointer:coarse)');
+function setSelection(id, opts) {
+  S.selection = id;
+  changed();
+  if (id && opts && opts.fromCanvas && COARSE.matches && elDetail) {
+    try {
+      elDetail.scrollIntoView({ block: 'start', behavior: RM.matches ? 'auto' : 'smooth' });
+    } catch (_) { elDetail.scrollIntoView(true); }
+  }
+}
 
 /* ------------------------------------------------------------------- globe */
 let gDrag = null, gMoved = 0;
@@ -155,7 +171,7 @@ function endGlobeDrag(e) {
       const d = Math.hypot(h.x - mx, h.y - my);
       if (d < h.r && d < bd) { bd = d; best = h; }
     }
-    setSelection(best ? best.id : null);
+    setSelection(best ? best.id : null, { fromCanvas: true });
   }
 }
 /* Lifting a finger mid-pinch must not end the gesture, and must not be read as a
@@ -263,7 +279,8 @@ ccv.addEventListener('pointermove', e => {
 });
 
 ccv.addEventListener('pointerup', e => {
-  if (cDrag && cDrag.mode === 'click') setSelection(cDrag.id === S.selection ? null : cDrag.id);
+  if (cDrag && cDrag.mode === 'click')
+    setSelection(cDrag.id === S.selection ? null : cDrag.id, { fromCanvas: true });
   else if (cDrag && cDrag.mode === 'pan' && cDrag.moved < 2) {
     const sc = SCALE || chronScale();
     S.cursor = Math.max(0, Math.min(T_MAX, sc.t(chronPos(e).x)));

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -441,6 +441,113 @@ def run(url, headed, report):
         browser.close()
 
 
+def run_mobile(url, headed, report):
+    """The phone build, from outside, at 390x844 with real touch.
+
+    Everything above runs at 1440x900, which is exactly the width at which the
+    phone layout's blockers are invisible: the stage control strip only grows
+    off the left edge once the stage is narrow, and the detail panel is only
+    a thousand pixels below the fold once .instrument is in grid row 3.
+    """
+    from playwright.sync_api import sync_playwright
+
+    print("\n  -- phone, 390x844, touch --", flush=True)
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=not headed)
+        ctx = browser.new_context(viewport={"width": 390, "height": 844},
+                                  device_scale_factor=2, has_touch=True, is_mobile=True)
+        page = ctx.new_page()
+        page_errors = []
+        page.on("pageerror", lambda e: page_errors.append(str(e)))
+        page.goto(url, wait_until="load", timeout=45000)
+        page.wait_for_timeout(1600)
+        report.check("the phone build boots", page.evaluate("window.__BOOT_OK") is True,
+                     str(page.evaluate("window.__BOOT_ERR"))[:120])
+
+        # ------------- every stage control can actually be reached by a finger
+        # .stage-tr was shrink-to-fit anchored right inside an overflow:hidden
+        # stage, so it grew off the LEFT edge: at 390px "Guided path" spanned
+        # -64 to -1, and #btn-tour is the tour's only entry point - S.tour is
+        # not in the hash and there is no keyboard binding.
+        unreachable = page.evaluate("""() => {
+          const strip = document.querySelector('.stage-tr');
+          const bad = [];
+          for (const b of strip.querySelectorAll('.iconbtn')) {
+            // scroll the strip to the button the way a finger would, then ask
+            // the document what is actually on top of its centre.
+            b.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+            const r = b.getBoundingClientRect();
+            const el = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+            if (!(el === b || b.contains(el))) {
+              bad.push({ t: b.textContent.trim(), l: Math.round(r.left), r: Math.round(r.right) });
+            }
+          }
+          strip.scrollLeft = 0;
+          return bad;
+        }""")
+        report.check("every stage control is reachable on a phone",
+                     unreachable == [], json.dumps(unreachable)[:200])
+
+        # ----------------------------------- a tap on a marker shows something
+        # The detail panel is grid row 3 under a 46vh stage - measured at
+        # detailTop 1169 in an 870px viewport - and the tooltip never fires on
+        # touch, so the tap changed nothing the tapper could see.
+        page.evaluate("scrollTo(0, 0); S.selection = null; markAll(); renderNow();")
+        page.wait_for_timeout(250)
+        pick = page.evaluate("""() => {
+          let best = null, bd = 1e18;
+          for (const h of HIT) {
+            if (!h.id) continue;
+            const dx = h.x - GW / 2, dy = h.y - GH / 2, d = dx * dx + dy * dy;
+            if (d < bd && h.x > 40 && h.y > 70 && h.x < GW - 40 && h.y < GH - 40) { bd = d; best = h; }
+          }
+          const r = document.getElementById('globe').getBoundingClientRect();
+          return best ? { x: r.left + best.x, y: r.top + best.y, id: best.id } : null;
+        }""")
+        if report.check("the phone globe has a marker to tap", pick is not None):
+            page.touchscreen.tap(pick["x"], pick["y"])
+            page.wait_for_timeout(900)
+            after = page.evaluate("""() => {
+              const r = document.getElementById('detail').getBoundingClientRect();
+              return { sel: S.selection, top: Math.round(r.top), vh: innerHeight };
+            }""")
+            report.check("tapping a marker brings its panel into view",
+                         after["sel"] is not None and after["top"] < after["vh"] - 40,
+                         json.dumps(after))
+
+        # ------------------ choosing a search result flies something in view
+        page.evaluate("scrollTo(0, document.body.scrollHeight)")
+        page.wait_for_timeout(250)
+        page.fill("#search", "iridium")
+        page.wait_for_timeout(300)
+        page.press("#search", "Enter")
+        page.wait_for_timeout(1200)
+        flew = page.evaluate("""() => ({
+          sel: S.selection,
+          stageTop: Math.round(document.getElementById('stage').getBoundingClientRect().top)
+        })""")
+        report.check("choosing a search result flies a globe you can see",
+                     flew["sel"] is not None and flew["stageTop"] > -40, json.dumps(flew))
+
+        # ------------------------------------------- the globe's focus ring
+        # #globe is exactly .stage, and .stage is overflow:hidden, so an
+        # outline painted 2px outside the border box is clipped entirely.
+        ring = page.evaluate("""() => {
+          const g = document.getElementById('globe');
+          g.focus();
+          const cs = getComputedStyle(g);
+          return { outlineWidth: cs.outlineWidth, offset: cs.outlineOffset, shadow: cs.boxShadow };
+        }""")
+        report.check("the globe's focus ring is painted inside its own box",
+                     "inset" in (ring["shadow"] or "")
+                     or (ring["offset"] or "").startswith("-"),
+                     json.dumps(ring)[:140])
+
+        report.check("no page errors on the phone build", not page_errors,
+                     " | ".join(page_errors[:2]))
+        browser.close()
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--url", default=None, help="test a deployed URL instead of the local build")
@@ -461,6 +568,7 @@ def main():
     report = Report()
     try:
         run(url, a.headed, report)
+        run_mobile(url, a.headed, report)
     finally:
         if httpd:
             httpd.shutdown()


### PR DESCRIPTION
Wave 2 of the bug audit. Four bugs that only exist below 860 px — which is exactly why nothing caught them: every one of the 44 existing checks runs at 1440×900.

Closes #7, closes #8, closes #9. Implements item 1 and the globe half of item 10 of `docs/ux-review-2026-08-03.md`.

## The strip that runs off the left edge

`.stage-tr` is a shrink-to-fit flex row anchored right, inside `.stage { overflow: hidden }`. As the stage narrows the row grows off the **left** edge and is clipped. Measured with `is_mobile`, `has_touch`:

| | 390×844 (stage 306) | 360×780 (stage 276) |
|---|---|---|
| strip spans | −64 → 294 | −94 → 264 |
| off-screen | Guided path | Guided path, Compare eras |

`document.scrollWidth === innerWidth`, so nothing scrolls to reach them, and `elementFromPoint` at the centre of `#btn-tour` returns `null`. `#btn-tour` is the tour's **only** entry point — `S.tour` is not in `encodeHash()` and there is no keyboard binding.

The strip now spans the stage and scrolls, starting at `flex-start`. That detail is not cosmetic: content overflowing the **start** edge of a flex scroll container cannot be scrolled to in Chromium or WebKit, so `flex-end` would have moved the problem rather than fixed it.

## A tap that changes nothing you can see

```
before tap:  detailTop 1169   innerHeight 870   scrollY 0
after tap:   S.selection 'homo_sapiens'   scrollY 0   detailTop 1169
             tooltip visible: false
```

The panel is grid row 3 under a 46vh stage, and the tooltip cannot cover for it — the hover branch sits after `if (gDrag) { … return; }`, so it never fires on touch. `elDetail.scrollTop = 0` is a no-op because the phone layout sets `.detail { overflow: visible }`.

`setSelection` now takes where the selection came from as an argument rather than guessing. Only a tap **on a canvas**, and only under a coarse pointer, scrolls the panel up: `Escape` passes null, a `data-goto` hop is already inside the panel, and the guided path's `flyTo` is driving the stage itself.

## A fly-to you cannot watch

Search `iridium`, press Enter, at 390×844: `S.selection 'chicxulub_impact'`, `stageTop −892`. The globe tweened for 1.1 s, most of a screen above the viewport. Now the stage is brought back first — a no-op on desktop, where the body does not scroll.

## A focus ring that is clipped away

`#globe` is exactly the size of `.stage`, `.stage` is `overflow: hidden`, and the shared `:focus-visible` rule paints 2 px *outside* the border box. On a `role="application"` element whose handler calls `preventDefault()` on all four arrow keys, that leaves a keyboard user with no sign of where focus is. Painted inset instead, leaving the shared rule alone for every other control.

## Verification

The suite now opens a second context at 390×844 with real touch, after the desktop run.

```
python3 tools/validate_graph.py    ERRORS (0)
python3 tools/check_no_local_paths.py --all    clean
python3 tools/build.py             51/51 checks passed
```

Each new check confirmed against the bug reintroduced:

```
[FAIL] every stage control is reachable on a phone   [{"t":"Guided path","l":-64,"r":-1}]
[FAIL] tapping a marker brings its panel into view   {"sel":"homo_sapiens","top":1169,"vh":870}
[FAIL] choosing a search result flies a globe you can see   {"sel":"chicxulub_impact","stageTop":-892}
[FAIL] the globe's focus ring is painted inside its own box   {"outlineWidth":"2px","offset":"2px","shadow":"none"}
47/51 checks passed
```

and 51/51 with the fixes restored.

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_