### PR TITLE
Say why something is not there, and land every hop somewhere you can see

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,16 @@ rotate the globe, does a pinch zoom it, does a cancelled pinch strand the
 gesture, does the K–Pg link still appear in 1980 and harden in 1991, does a
 shared URL restore the view, can a hostile hash poison it, is a marker only as
 clickable as it is big, do the rival markers agree with the band they sit in, and
-does toggling the basemap reach the URL.
+does toggling the basemap reach the URL, does a link to something not yet known
+explain itself rather than reading as empty, does a hop inside the panel land on
+something that is actually drawn, does revealing something already on screen
+leave the window alone, and is `Compare eras` as modal as it declares itself.
 
 Then it opens a second context at 390x844 with real touch and asks the phone
 build the questions the desktop one cannot: can a finger reach every control on
 the stage, does tapping a marker put its panel where you can see it, does
 choosing a search result fly a globe that is on screen, is the globe's focus
-ring inside its own clipping box. 51 checks, wired into `build.py`, exits
+ring inside its own clipping box. 59 checks, wired into `build.py`, exits
 non-zero.
 
 It exists because this project lost an entire build to a boot failure that
@@ -195,16 +198,19 @@ and live by 1985. It exits non-zero on any of those.
   endpoint is a referent that does not exist yet. They render in the panel and
   say nothing to the graph.
 - **Not React.** See below.
-- **A UX review found twelve items; item 1 and the globe half of item 10 are
-  done, the rest are not.** The phone blockers are fixed — the stage control
+- **A UX review found twelve items; items 1 and 4 and both halves of item 10
+  that concern this site are done, the rest are not.** The phone blockers are fixed — the stage control
   strip no longer runs off the left edge (`Guided path` was entirely off-screen,
   and it is the tour's only entry point), a tap on a marker now scrolls its
   panel into view, a chosen search result no longer flies a globe that is above
   the viewport, and the globe's focus ring is painted inside its own clipping
   box instead of being clipped away. All four are asserted by the phone section
-  of the smoke test. Still open: the scroll-versus-rotate conflict on touch,
-  light-mode contrast on the stage overlays, `goTo()` bypassing `chooseResult`'s
-  gating, and the rest. See [`docs/ux-review-2026-08-03.md`](docs/ux-review-2026-08-03.md),
+  of the smoke test. A hop inside the panel now goes through the same gate
+  `chooseResult` does — and that gate no longer throws away a window someone
+  panned to in order to reveal something already inside it — and `Compare eras`
+  now makes the rest of the page `inert` instead of only claiming to. Still
+  open: the scroll-versus-rotate conflict on touch, light-mode contrast on the
+  stage overlays, and the rest. See [`docs/ux-review-2026-08-03.md`](docs/ux-review-2026-08-03.md),
   which covers this site and its sibling together.
 
 ## Two deliberate departures

--- a/artifact.html
+++ b/artifact.html
@@ -2253,6 +2253,44 @@ function edgeLink(ed, dir) {
 
 function renderDetail() {
   const F = facts();
+
+  /* A real referent that resolve() cannot place at this knowledge-time. Reached
+     by a shared link - #k=1700&s=homo_sapiens - and it used to fall through to
+     "Nothing selected" while the selection was set and still in the URL. That is
+     not an error state: it is the most interesting thing the page has to say,
+     and resolve() has already worked out the year it changes. */
+  if (S.selection && !F.items[S.selection] &&
+      Object.prototype.hasOwnProperty.call(R.referents, S.selection)) {
+    const ref = R.referents[S.selection];
+    const first = firstDatedYear(S.selection);
+    const pending = (R.byRef[S.selection] || [])
+      .filter(c => c.knowledge_time > S.kt)
+      .sort((a, b) => a.knowledge_time - b.knowledge_time);
+    elDetail.innerHTML = `
+      <div class="dt-head">
+        <div class="dt-kind"><span class="tag">${esc(ref.kind)}</span></div>
+        <h2>${esc(ref.label)}</h2>
+      </div>
+      <div class="resolved">
+        <span class="lbl" style="display:block;margin-bottom:4px">Not yet known in ${S.kt}</span>
+        <div class="big">no dated claim</div>
+        <p class="prov">Nothing datable has been asserted about this in
+        <b class="num">${S.kt}</b>. The page is not hiding it — in this year, nobody
+        had put a number on it.</p>
+        ${isFinite(first) ? `<p class="prov"><button class="edge-link" data-goto="${esc(ref.id)}"
+          style="padding:2px 0"><span><span class="who">Go to ${first}</span>
+          <span class="mech">the year the first dated claim arrives</span></span></button></p>` : ''}
+      </div>
+      ${pending.length ? `<div class="sect">
+        <span class="lbl">What is still to come · ${pending.length}</span>
+        ${pending.slice(0, 8).map(c => `<div class="claim pending" style="--cl:var(--rule)">
+          <p class="stmt">${esc(c.statement)}</p>
+          <p class="src">${esc(c.asserted_by)} — arrives in <span class="kt num">${c.knowledge_time}</span></p>
+        </div>`).join('')}
+      </div>` : ''}`;
+    return;
+  }
+
   if (!S.selection || !F.items[S.selection]) {
     const disp = F.visible.filter(i => i.res.disputed)
       .sort((a, b) => (b.res.oldest - b.res.youngest) - (a.res.oldest - a.res.youngest))
@@ -2473,8 +2511,7 @@ const SEARCH_IDX = (() => {
       // The year resolve() can first place it, not the year anyone first said
       // anything about it - those differ, and the label has to match what
       // choosing the row will actually do.
-      first: claims.filter(c => !c._meta && isFinite(c.earth_time_start))
-        .reduce((m, c) => Math.min(m, c.knowledge_time), Infinity)
+      first: firstDatedYear(id)
     });
   }
   return out;
@@ -2538,20 +2575,31 @@ function closeResults() {
   elSearchNote.textContent = '';
 }
 
-/* Getting there is not enough: a result can be invisible because knowledge-time
-   is earlier than the claim, because its field of study is switched off, or
-   because another field is isolated. Choosing it opens whatever is in the way. */
-function chooseResult(id) {
-  if (!Object.prototype.hasOwnProperty.call(R.referents, id)) return;
-  const claims = R.byRef[id] || [];
+/** The year resolve() can first place a referent, or Infinity if it never can. */
+function firstDatedYear(id) {
+  return (R.byRef[id] || [])
+    /* Only claims that resolve() will actually count. Taking the minimum over
+       ALL claims picks up undated and _meta ones, so a referent whose earliest
+       DATED claim is 1953 but which carries a 1785 interpretation reported
+       "first claimed 1785" and then selected into an empty panel, because
+       resolve() returns null when nothing dated is live. Mirror its predicate. */
+    .filter(c => !c._meta && isFinite(c.earth_time_start))
+    .reduce((m, c) => Math.min(m, c.knowledge_time), Infinity);
+}
+
+/* Getting there is not enough: a referent can be invisible because
+   knowledge-time is earlier than the claim, because its field of study is
+   switched off, or because another field is isolated. This opens whatever is in
+   the way and returns the view that shows it — it mutates the filters, and
+   leaves the flying to the caller.
+
+   It exists because chooseResult did all of this and the panel's own Connections
+   links did none of it: a hop selected a referent with no mark on the globe or
+   the timeline and rendered a full panel for it anyway. */
+function revealReferent(id) {
+  if (!Object.prototype.hasOwnProperty.call(R.referents, id)) return null;
   let kt = S.kt;
-  /* Only claims that resolve() will actually count. Taking the minimum over ALL
-     claims picks up undated and _meta ones, so a referent whose earliest DATED
-     claim is 1953 but which carries a 1785 interpretation reported "first
-     claimed 1785" and then selected into an empty panel, because resolve()
-     returns null when nothing dated is live. Mirror its predicate exactly. */
-  const dated = claims.filter(c => !c._meta && isFinite(c.earth_time_start));
-  const first = dated.reduce((m, c) => Math.min(m, c.knowledge_time), Infinity);
+  const first = firstDatedYear(id);
   if (isFinite(first) && first > kt) kt = Math.min(KT_MAX, first);
 
   const res = resolve(id, kt, S.resolver);
@@ -2559,9 +2607,20 @@ function chooseResult(id) {
     if (S.focus && !res.subjects.includes(S.focus)) S.focus = null;
     if (!res.subjects.some(s => S.subjects.has(s))) for (const s of res.subjects) S.subjects.add(s);
   }
-  const t1 = res && isFinite(res.oldest)
-    ? Math.max(2000, Math.min(T_MAX, res.oldest * 1.7))
-    : S.win.t1;
+  /* Widen only when the target is actually outside the window. Widening every
+     time threw away a window someone had panned to, in order to "reveal"
+     something that was already inside it. */
+  let win = [S.win.t0, S.win.t1];
+  if (res && isFinite(res.oldest) &&
+      (res.oldest > S.win.t1 || res.youngest < S.win.t0)) {
+    win = [0, Math.max(2000, Math.min(T_MAX, res.oldest * 1.7))];
+  }
+  return { id, kt, win, res };
+}
+
+function chooseResult(id) {
+  const plan = revealReferent(id);
+  if (!plan) return;
   closeResults();
   elSearch.blur();
   /* On a phone the search box is in grid row 3 and the globe is row 1, so
@@ -2573,7 +2632,7 @@ function chooseResult(id) {
     try { stage.scrollIntoView({ block: 'start', behavior: RM.matches ? 'auto' : 'smooth' }); }
     catch (_) { stage.scrollIntoView(true); }
   }
-  flyTo({ id, kt, win: [0, t1] });
+  flyTo(plan);
 }
 
 let searchTimer = null;
@@ -3151,9 +3210,16 @@ document.getElementById('subjects').addEventListener('dblclick', e => {
   changed();
 });
 
+/* A Connections link used to be a bare setSelection, which skipped every gate
+   chooseResult applies: with a subject switched off it selected a referent with
+   no mark on the globe or the timeline and rendered a full panel for it anyway.
+   Same helper, same guarantees. No stage scroll - the reader is looking at the
+   panel, and the panel rebuilds in place. */
 elDetail.addEventListener('click', e => {
   const b = e.target.closest('[data-goto]'); if (!b) return;
-  setSelection(b.dataset.goto);
+  const plan = revealReferent(b.dataset.goto);
+  if (!plan) return;
+  flyTo(plan);
   elDetail.scrollTop = 0;
 });
 
@@ -3187,24 +3253,65 @@ document.getElementById('btn-theme').addEventListener('click', () => {
 });
 matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => { readPalette(); markAll(); });
 
+/* The dialog carries role="dialog" aria-modal="true", which tells assistive
+   technology that everything outside it is hidden. Nothing made that true:
+   focus stayed on the opener - inside the part just declared hidden - thirty
+   background controls remained tabbable, and Tab walked straight out. inert
+   makes the claim honest, and the opener gets its focus back on the way out. */
 const diffwrap = document.getElementById('diffwrap');
-document.getElementById('btn-diff').addEventListener('click', e => {
-  const on = diffwrap.hidden;
+const btnDiff = document.getElementById('btn-diff');
+const diffA = document.getElementById('diff-a');
+const diffB = document.getElementById('diff-b');
+let diffOpener = null;
+
+function setDiffOpen(on) {
+  if (on === !diffwrap.hidden) return;
   diffwrap.hidden = !on;
-  e.currentTarget.setAttribute('aria-pressed', String(on));
-  if (on) { document.getElementById('diff-b').value = S.kt; renderDiff(); }
-});
-document.getElementById('diff-close').addEventListener('click', () => {
-  diffwrap.hidden = true;
-  document.getElementById('btn-diff').setAttribute('aria-pressed', 'false');
-});
-document.getElementById('diff-a').addEventListener('input', e => { S.ktA = +e.target.value || 1975; renderDiff(); });
-document.getElementById('diff-b').addEventListener('input', e => { setKt(+e.target.value || KT_MAX); renderDiff(); });
-document.addEventListener('keydown', e => {
-  if (e.key === 'Escape' && !diffwrap.hidden) {
-    diffwrap.hidden = true;
-    document.getElementById('btn-diff').setAttribute('aria-pressed', 'false');
+  btnDiff.setAttribute('aria-pressed', String(on));
+  for (const el of [document.querySelector('.app'), document.getElementById('tourbar')]) {
+    if (el) el.toggleAttribute('inert', on);
   }
+  if (on) {
+    diffOpener = document.activeElement;
+    diffB.value = S.kt;
+    diffA.value = S.ktA;
+    renderDiff();
+    diffA.focus();
+  } else {
+    const back = diffOpener && diffOpener.isConnected ? diffOpener : btnDiff;
+    diffOpener = null;
+    try { back.focus(); } catch (_) { /* it may have gone away; never fatal */ }
+  }
+}
+
+btnDiff.addEventListener('click', () => setDiffOpen(diffwrap.hidden));
+document.getElementById('diff-close').addEventListener('click', () => setDiffOpen(false));
+
+/* Take a year only once it is a complete one that exists on the rail. Clamping
+   per keystroke would snap the "1" on the way to "1850" to 1650 and make the
+   field unusable; `+value || dflt` was worse still, because 0 is falsy, so the
+   first character of "2000" silently jumped the comparison to 1975. The field
+   is reconciled with the state on change, so it can never be left showing a
+   year the page is not actually comparing. */
+function yearFromInput(el) {
+  const n = parseInt(el.value, 10);
+  return isFinite(n) && n >= KT_MIN && n <= KT_MAX ? n : null;
+}
+diffA.addEventListener('input', () => {
+  const n = yearFromInput(diffA);
+  if (n === null) return;
+  S.ktA = n; renderDiff();
+});
+diffB.addEventListener('input', () => {
+  const n = yearFromInput(diffB);
+  if (n === null) return;
+  setKt(n); renderDiff();
+});
+diffA.addEventListener('change', () => { diffA.value = S.ktA; renderDiff(); });
+diffB.addEventListener('change', () => { diffB.value = S.kt; renderDiff(); });
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape' && !diffwrap.hidden) setDiffOpen(false);
 });
 
 /* -------------------------------------------------------------- guided path */

--- a/earth-x-time.html
+++ b/earth-x-time.html
@@ -2260,6 +2260,44 @@ function edgeLink(ed, dir) {
 
 function renderDetail() {
   const F = facts();
+
+  /* A real referent that resolve() cannot place at this knowledge-time. Reached
+     by a shared link - #k=1700&s=homo_sapiens - and it used to fall through to
+     "Nothing selected" while the selection was set and still in the URL. That is
+     not an error state: it is the most interesting thing the page has to say,
+     and resolve() has already worked out the year it changes. */
+  if (S.selection && !F.items[S.selection] &&
+      Object.prototype.hasOwnProperty.call(R.referents, S.selection)) {
+    const ref = R.referents[S.selection];
+    const first = firstDatedYear(S.selection);
+    const pending = (R.byRef[S.selection] || [])
+      .filter(c => c.knowledge_time > S.kt)
+      .sort((a, b) => a.knowledge_time - b.knowledge_time);
+    elDetail.innerHTML = `
+      <div class="dt-head">
+        <div class="dt-kind"><span class="tag">${esc(ref.kind)}</span></div>
+        <h2>${esc(ref.label)}</h2>
+      </div>
+      <div class="resolved">
+        <span class="lbl" style="display:block;margin-bottom:4px">Not yet known in ${S.kt}</span>
+        <div class="big">no dated claim</div>
+        <p class="prov">Nothing datable has been asserted about this in
+        <b class="num">${S.kt}</b>. The page is not hiding it — in this year, nobody
+        had put a number on it.</p>
+        ${isFinite(first) ? `<p class="prov"><button class="edge-link" data-goto="${esc(ref.id)}"
+          style="padding:2px 0"><span><span class="who">Go to ${first}</span>
+          <span class="mech">the year the first dated claim arrives</span></span></button></p>` : ''}
+      </div>
+      ${pending.length ? `<div class="sect">
+        <span class="lbl">What is still to come · ${pending.length}</span>
+        ${pending.slice(0, 8).map(c => `<div class="claim pending" style="--cl:var(--rule)">
+          <p class="stmt">${esc(c.statement)}</p>
+          <p class="src">${esc(c.asserted_by)} — arrives in <span class="kt num">${c.knowledge_time}</span></p>
+        </div>`).join('')}
+      </div>` : ''}`;
+    return;
+  }
+
   if (!S.selection || !F.items[S.selection]) {
     const disp = F.visible.filter(i => i.res.disputed)
       .sort((a, b) => (b.res.oldest - b.res.youngest) - (a.res.oldest - a.res.youngest))
@@ -2480,8 +2518,7 @@ const SEARCH_IDX = (() => {
       // The year resolve() can first place it, not the year anyone first said
       // anything about it - those differ, and the label has to match what
       // choosing the row will actually do.
-      first: claims.filter(c => !c._meta && isFinite(c.earth_time_start))
-        .reduce((m, c) => Math.min(m, c.knowledge_time), Infinity)
+      first: firstDatedYear(id)
     });
   }
   return out;
@@ -2545,20 +2582,31 @@ function closeResults() {
   elSearchNote.textContent = '';
 }
 
-/* Getting there is not enough: a result can be invisible because knowledge-time
-   is earlier than the claim, because its field of study is switched off, or
-   because another field is isolated. Choosing it opens whatever is in the way. */
-function chooseResult(id) {
-  if (!Object.prototype.hasOwnProperty.call(R.referents, id)) return;
-  const claims = R.byRef[id] || [];
+/** The year resolve() can first place a referent, or Infinity if it never can. */
+function firstDatedYear(id) {
+  return (R.byRef[id] || [])
+    /* Only claims that resolve() will actually count. Taking the minimum over
+       ALL claims picks up undated and _meta ones, so a referent whose earliest
+       DATED claim is 1953 but which carries a 1785 interpretation reported
+       "first claimed 1785" and then selected into an empty panel, because
+       resolve() returns null when nothing dated is live. Mirror its predicate. */
+    .filter(c => !c._meta && isFinite(c.earth_time_start))
+    .reduce((m, c) => Math.min(m, c.knowledge_time), Infinity);
+}
+
+/* Getting there is not enough: a referent can be invisible because
+   knowledge-time is earlier than the claim, because its field of study is
+   switched off, or because another field is isolated. This opens whatever is in
+   the way and returns the view that shows it — it mutates the filters, and
+   leaves the flying to the caller.
+
+   It exists because chooseResult did all of this and the panel's own Connections
+   links did none of it: a hop selected a referent with no mark on the globe or
+   the timeline and rendered a full panel for it anyway. */
+function revealReferent(id) {
+  if (!Object.prototype.hasOwnProperty.call(R.referents, id)) return null;
   let kt = S.kt;
-  /* Only claims that resolve() will actually count. Taking the minimum over ALL
-     claims picks up undated and _meta ones, so a referent whose earliest DATED
-     claim is 1953 but which carries a 1785 interpretation reported "first
-     claimed 1785" and then selected into an empty panel, because resolve()
-     returns null when nothing dated is live. Mirror its predicate exactly. */
-  const dated = claims.filter(c => !c._meta && isFinite(c.earth_time_start));
-  const first = dated.reduce((m, c) => Math.min(m, c.knowledge_time), Infinity);
+  const first = firstDatedYear(id);
   if (isFinite(first) && first > kt) kt = Math.min(KT_MAX, first);
 
   const res = resolve(id, kt, S.resolver);
@@ -2566,9 +2614,20 @@ function chooseResult(id) {
     if (S.focus && !res.subjects.includes(S.focus)) S.focus = null;
     if (!res.subjects.some(s => S.subjects.has(s))) for (const s of res.subjects) S.subjects.add(s);
   }
-  const t1 = res && isFinite(res.oldest)
-    ? Math.max(2000, Math.min(T_MAX, res.oldest * 1.7))
-    : S.win.t1;
+  /* Widen only when the target is actually outside the window. Widening every
+     time threw away a window someone had panned to, in order to "reveal"
+     something that was already inside it. */
+  let win = [S.win.t0, S.win.t1];
+  if (res && isFinite(res.oldest) &&
+      (res.oldest > S.win.t1 || res.youngest < S.win.t0)) {
+    win = [0, Math.max(2000, Math.min(T_MAX, res.oldest * 1.7))];
+  }
+  return { id, kt, win, res };
+}
+
+function chooseResult(id) {
+  const plan = revealReferent(id);
+  if (!plan) return;
   closeResults();
   elSearch.blur();
   /* On a phone the search box is in grid row 3 and the globe is row 1, so
@@ -2580,7 +2639,7 @@ function chooseResult(id) {
     try { stage.scrollIntoView({ block: 'start', behavior: RM.matches ? 'auto' : 'smooth' }); }
     catch (_) { stage.scrollIntoView(true); }
   }
-  flyTo({ id, kt, win: [0, t1] });
+  flyTo(plan);
 }
 
 let searchTimer = null;
@@ -3158,9 +3217,16 @@ document.getElementById('subjects').addEventListener('dblclick', e => {
   changed();
 });
 
+/* A Connections link used to be a bare setSelection, which skipped every gate
+   chooseResult applies: with a subject switched off it selected a referent with
+   no mark on the globe or the timeline and rendered a full panel for it anyway.
+   Same helper, same guarantees. No stage scroll - the reader is looking at the
+   panel, and the panel rebuilds in place. */
 elDetail.addEventListener('click', e => {
   const b = e.target.closest('[data-goto]'); if (!b) return;
-  setSelection(b.dataset.goto);
+  const plan = revealReferent(b.dataset.goto);
+  if (!plan) return;
+  flyTo(plan);
   elDetail.scrollTop = 0;
 });
 
@@ -3194,24 +3260,65 @@ document.getElementById('btn-theme').addEventListener('click', () => {
 });
 matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => { readPalette(); markAll(); });
 
+/* The dialog carries role="dialog" aria-modal="true", which tells assistive
+   technology that everything outside it is hidden. Nothing made that true:
+   focus stayed on the opener - inside the part just declared hidden - thirty
+   background controls remained tabbable, and Tab walked straight out. inert
+   makes the claim honest, and the opener gets its focus back on the way out. */
 const diffwrap = document.getElementById('diffwrap');
-document.getElementById('btn-diff').addEventListener('click', e => {
-  const on = diffwrap.hidden;
+const btnDiff = document.getElementById('btn-diff');
+const diffA = document.getElementById('diff-a');
+const diffB = document.getElementById('diff-b');
+let diffOpener = null;
+
+function setDiffOpen(on) {
+  if (on === !diffwrap.hidden) return;
   diffwrap.hidden = !on;
-  e.currentTarget.setAttribute('aria-pressed', String(on));
-  if (on) { document.getElementById('diff-b').value = S.kt; renderDiff(); }
-});
-document.getElementById('diff-close').addEventListener('click', () => {
-  diffwrap.hidden = true;
-  document.getElementById('btn-diff').setAttribute('aria-pressed', 'false');
-});
-document.getElementById('diff-a').addEventListener('input', e => { S.ktA = +e.target.value || 1975; renderDiff(); });
-document.getElementById('diff-b').addEventListener('input', e => { setKt(+e.target.value || KT_MAX); renderDiff(); });
-document.addEventListener('keydown', e => {
-  if (e.key === 'Escape' && !diffwrap.hidden) {
-    diffwrap.hidden = true;
-    document.getElementById('btn-diff').setAttribute('aria-pressed', 'false');
+  btnDiff.setAttribute('aria-pressed', String(on));
+  for (const el of [document.querySelector('.app'), document.getElementById('tourbar')]) {
+    if (el) el.toggleAttribute('inert', on);
   }
+  if (on) {
+    diffOpener = document.activeElement;
+    diffB.value = S.kt;
+    diffA.value = S.ktA;
+    renderDiff();
+    diffA.focus();
+  } else {
+    const back = diffOpener && diffOpener.isConnected ? diffOpener : btnDiff;
+    diffOpener = null;
+    try { back.focus(); } catch (_) { /* it may have gone away; never fatal */ }
+  }
+}
+
+btnDiff.addEventListener('click', () => setDiffOpen(diffwrap.hidden));
+document.getElementById('diff-close').addEventListener('click', () => setDiffOpen(false));
+
+/* Take a year only once it is a complete one that exists on the rail. Clamping
+   per keystroke would snap the "1" on the way to "1850" to 1650 and make the
+   field unusable; `+value || dflt` was worse still, because 0 is falsy, so the
+   first character of "2000" silently jumped the comparison to 1975. The field
+   is reconciled with the state on change, so it can never be left showing a
+   year the page is not actually comparing. */
+function yearFromInput(el) {
+  const n = parseInt(el.value, 10);
+  return isFinite(n) && n >= KT_MIN && n <= KT_MAX ? n : null;
+}
+diffA.addEventListener('input', () => {
+  const n = yearFromInput(diffA);
+  if (n === null) return;
+  S.ktA = n; renderDiff();
+});
+diffB.addEventListener('input', () => {
+  const n = yearFromInput(diffB);
+  if (n === null) return;
+  setKt(n); renderDiff();
+});
+diffA.addEventListener('change', () => { diffA.value = S.ktA; renderDiff(); });
+diffB.addEventListener('change', () => { diffB.value = S.kt; renderDiff(); });
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape' && !diffwrap.hidden) setDiffOpen(false);
 });
 
 /* -------------------------------------------------------------- guided path */

--- a/index.html
+++ b/index.html
@@ -2260,6 +2260,44 @@ function edgeLink(ed, dir) {
 
 function renderDetail() {
   const F = facts();
+
+  /* A real referent that resolve() cannot place at this knowledge-time. Reached
+     by a shared link - #k=1700&s=homo_sapiens - and it used to fall through to
+     "Nothing selected" while the selection was set and still in the URL. That is
+     not an error state: it is the most interesting thing the page has to say,
+     and resolve() has already worked out the year it changes. */
+  if (S.selection && !F.items[S.selection] &&
+      Object.prototype.hasOwnProperty.call(R.referents, S.selection)) {
+    const ref = R.referents[S.selection];
+    const first = firstDatedYear(S.selection);
+    const pending = (R.byRef[S.selection] || [])
+      .filter(c => c.knowledge_time > S.kt)
+      .sort((a, b) => a.knowledge_time - b.knowledge_time);
+    elDetail.innerHTML = `
+      <div class="dt-head">
+        <div class="dt-kind"><span class="tag">${esc(ref.kind)}</span></div>
+        <h2>${esc(ref.label)}</h2>
+      </div>
+      <div class="resolved">
+        <span class="lbl" style="display:block;margin-bottom:4px">Not yet known in ${S.kt}</span>
+        <div class="big">no dated claim</div>
+        <p class="prov">Nothing datable has been asserted about this in
+        <b class="num">${S.kt}</b>. The page is not hiding it — in this year, nobody
+        had put a number on it.</p>
+        ${isFinite(first) ? `<p class="prov"><button class="edge-link" data-goto="${esc(ref.id)}"
+          style="padding:2px 0"><span><span class="who">Go to ${first}</span>
+          <span class="mech">the year the first dated claim arrives</span></span></button></p>` : ''}
+      </div>
+      ${pending.length ? `<div class="sect">
+        <span class="lbl">What is still to come · ${pending.length}</span>
+        ${pending.slice(0, 8).map(c => `<div class="claim pending" style="--cl:var(--rule)">
+          <p class="stmt">${esc(c.statement)}</p>
+          <p class="src">${esc(c.asserted_by)} — arrives in <span class="kt num">${c.knowledge_time}</span></p>
+        </div>`).join('')}
+      </div>` : ''}`;
+    return;
+  }
+
   if (!S.selection || !F.items[S.selection]) {
     const disp = F.visible.filter(i => i.res.disputed)
       .sort((a, b) => (b.res.oldest - b.res.youngest) - (a.res.oldest - a.res.youngest))
@@ -2480,8 +2518,7 @@ const SEARCH_IDX = (() => {
       // The year resolve() can first place it, not the year anyone first said
       // anything about it - those differ, and the label has to match what
       // choosing the row will actually do.
-      first: claims.filter(c => !c._meta && isFinite(c.earth_time_start))
-        .reduce((m, c) => Math.min(m, c.knowledge_time), Infinity)
+      first: firstDatedYear(id)
     });
   }
   return out;
@@ -2545,20 +2582,31 @@ function closeResults() {
   elSearchNote.textContent = '';
 }
 
-/* Getting there is not enough: a result can be invisible because knowledge-time
-   is earlier than the claim, because its field of study is switched off, or
-   because another field is isolated. Choosing it opens whatever is in the way. */
-function chooseResult(id) {
-  if (!Object.prototype.hasOwnProperty.call(R.referents, id)) return;
-  const claims = R.byRef[id] || [];
+/** The year resolve() can first place a referent, or Infinity if it never can. */
+function firstDatedYear(id) {
+  return (R.byRef[id] || [])
+    /* Only claims that resolve() will actually count. Taking the minimum over
+       ALL claims picks up undated and _meta ones, so a referent whose earliest
+       DATED claim is 1953 but which carries a 1785 interpretation reported
+       "first claimed 1785" and then selected into an empty panel, because
+       resolve() returns null when nothing dated is live. Mirror its predicate. */
+    .filter(c => !c._meta && isFinite(c.earth_time_start))
+    .reduce((m, c) => Math.min(m, c.knowledge_time), Infinity);
+}
+
+/* Getting there is not enough: a referent can be invisible because
+   knowledge-time is earlier than the claim, because its field of study is
+   switched off, or because another field is isolated. This opens whatever is in
+   the way and returns the view that shows it — it mutates the filters, and
+   leaves the flying to the caller.
+
+   It exists because chooseResult did all of this and the panel's own Connections
+   links did none of it: a hop selected a referent with no mark on the globe or
+   the timeline and rendered a full panel for it anyway. */
+function revealReferent(id) {
+  if (!Object.prototype.hasOwnProperty.call(R.referents, id)) return null;
   let kt = S.kt;
-  /* Only claims that resolve() will actually count. Taking the minimum over ALL
-     claims picks up undated and _meta ones, so a referent whose earliest DATED
-     claim is 1953 but which carries a 1785 interpretation reported "first
-     claimed 1785" and then selected into an empty panel, because resolve()
-     returns null when nothing dated is live. Mirror its predicate exactly. */
-  const dated = claims.filter(c => !c._meta && isFinite(c.earth_time_start));
-  const first = dated.reduce((m, c) => Math.min(m, c.knowledge_time), Infinity);
+  const first = firstDatedYear(id);
   if (isFinite(first) && first > kt) kt = Math.min(KT_MAX, first);
 
   const res = resolve(id, kt, S.resolver);
@@ -2566,9 +2614,20 @@ function chooseResult(id) {
     if (S.focus && !res.subjects.includes(S.focus)) S.focus = null;
     if (!res.subjects.some(s => S.subjects.has(s))) for (const s of res.subjects) S.subjects.add(s);
   }
-  const t1 = res && isFinite(res.oldest)
-    ? Math.max(2000, Math.min(T_MAX, res.oldest * 1.7))
-    : S.win.t1;
+  /* Widen only when the target is actually outside the window. Widening every
+     time threw away a window someone had panned to, in order to "reveal"
+     something that was already inside it. */
+  let win = [S.win.t0, S.win.t1];
+  if (res && isFinite(res.oldest) &&
+      (res.oldest > S.win.t1 || res.youngest < S.win.t0)) {
+    win = [0, Math.max(2000, Math.min(T_MAX, res.oldest * 1.7))];
+  }
+  return { id, kt, win, res };
+}
+
+function chooseResult(id) {
+  const plan = revealReferent(id);
+  if (!plan) return;
   closeResults();
   elSearch.blur();
   /* On a phone the search box is in grid row 3 and the globe is row 1, so
@@ -2580,7 +2639,7 @@ function chooseResult(id) {
     try { stage.scrollIntoView({ block: 'start', behavior: RM.matches ? 'auto' : 'smooth' }); }
     catch (_) { stage.scrollIntoView(true); }
   }
-  flyTo({ id, kt, win: [0, t1] });
+  flyTo(plan);
 }
 
 let searchTimer = null;
@@ -3158,9 +3217,16 @@ document.getElementById('subjects').addEventListener('dblclick', e => {
   changed();
 });
 
+/* A Connections link used to be a bare setSelection, which skipped every gate
+   chooseResult applies: with a subject switched off it selected a referent with
+   no mark on the globe or the timeline and rendered a full panel for it anyway.
+   Same helper, same guarantees. No stage scroll - the reader is looking at the
+   panel, and the panel rebuilds in place. */
 elDetail.addEventListener('click', e => {
   const b = e.target.closest('[data-goto]'); if (!b) return;
-  setSelection(b.dataset.goto);
+  const plan = revealReferent(b.dataset.goto);
+  if (!plan) return;
+  flyTo(plan);
   elDetail.scrollTop = 0;
 });
 
@@ -3194,24 +3260,65 @@ document.getElementById('btn-theme').addEventListener('click', () => {
 });
 matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => { readPalette(); markAll(); });
 
+/* The dialog carries role="dialog" aria-modal="true", which tells assistive
+   technology that everything outside it is hidden. Nothing made that true:
+   focus stayed on the opener - inside the part just declared hidden - thirty
+   background controls remained tabbable, and Tab walked straight out. inert
+   makes the claim honest, and the opener gets its focus back on the way out. */
 const diffwrap = document.getElementById('diffwrap');
-document.getElementById('btn-diff').addEventListener('click', e => {
-  const on = diffwrap.hidden;
+const btnDiff = document.getElementById('btn-diff');
+const diffA = document.getElementById('diff-a');
+const diffB = document.getElementById('diff-b');
+let diffOpener = null;
+
+function setDiffOpen(on) {
+  if (on === !diffwrap.hidden) return;
   diffwrap.hidden = !on;
-  e.currentTarget.setAttribute('aria-pressed', String(on));
-  if (on) { document.getElementById('diff-b').value = S.kt; renderDiff(); }
-});
-document.getElementById('diff-close').addEventListener('click', () => {
-  diffwrap.hidden = true;
-  document.getElementById('btn-diff').setAttribute('aria-pressed', 'false');
-});
-document.getElementById('diff-a').addEventListener('input', e => { S.ktA = +e.target.value || 1975; renderDiff(); });
-document.getElementById('diff-b').addEventListener('input', e => { setKt(+e.target.value || KT_MAX); renderDiff(); });
-document.addEventListener('keydown', e => {
-  if (e.key === 'Escape' && !diffwrap.hidden) {
-    diffwrap.hidden = true;
-    document.getElementById('btn-diff').setAttribute('aria-pressed', 'false');
+  btnDiff.setAttribute('aria-pressed', String(on));
+  for (const el of [document.querySelector('.app'), document.getElementById('tourbar')]) {
+    if (el) el.toggleAttribute('inert', on);
   }
+  if (on) {
+    diffOpener = document.activeElement;
+    diffB.value = S.kt;
+    diffA.value = S.ktA;
+    renderDiff();
+    diffA.focus();
+  } else {
+    const back = diffOpener && diffOpener.isConnected ? diffOpener : btnDiff;
+    diffOpener = null;
+    try { back.focus(); } catch (_) { /* it may have gone away; never fatal */ }
+  }
+}
+
+btnDiff.addEventListener('click', () => setDiffOpen(diffwrap.hidden));
+document.getElementById('diff-close').addEventListener('click', () => setDiffOpen(false));
+
+/* Take a year only once it is a complete one that exists on the rail. Clamping
+   per keystroke would snap the "1" on the way to "1850" to 1650 and make the
+   field unusable; `+value || dflt` was worse still, because 0 is falsy, so the
+   first character of "2000" silently jumped the comparison to 1975. The field
+   is reconciled with the state on change, so it can never be left showing a
+   year the page is not actually comparing. */
+function yearFromInput(el) {
+  const n = parseInt(el.value, 10);
+  return isFinite(n) && n >= KT_MIN && n <= KT_MAX ? n : null;
+}
+diffA.addEventListener('input', () => {
+  const n = yearFromInput(diffA);
+  if (n === null) return;
+  S.ktA = n; renderDiff();
+});
+diffB.addEventListener('input', () => {
+  const n = yearFromInput(diffB);
+  if (n === null) return;
+  setKt(n); renderDiff();
+});
+diffA.addEventListener('change', () => { diffA.value = S.ktA; renderDiff(); });
+diffB.addEventListener('change', () => { diffB.value = S.kt; renderDiff(); });
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape' && !diffwrap.hidden) setDiffOpen(false);
 });
 
 /* -------------------------------------------------------------- guided path */

--- a/src/70_panel.js
+++ b/src/70_panel.js
@@ -60,6 +60,44 @@ function edgeLink(ed, dir) {
 
 function renderDetail() {
   const F = facts();
+
+  /* A real referent that resolve() cannot place at this knowledge-time. Reached
+     by a shared link - #k=1700&s=homo_sapiens - and it used to fall through to
+     "Nothing selected" while the selection was set and still in the URL. That is
+     not an error state: it is the most interesting thing the page has to say,
+     and resolve() has already worked out the year it changes. */
+  if (S.selection && !F.items[S.selection] &&
+      Object.prototype.hasOwnProperty.call(R.referents, S.selection)) {
+    const ref = R.referents[S.selection];
+    const first = firstDatedYear(S.selection);
+    const pending = (R.byRef[S.selection] || [])
+      .filter(c => c.knowledge_time > S.kt)
+      .sort((a, b) => a.knowledge_time - b.knowledge_time);
+    elDetail.innerHTML = `
+      <div class="dt-head">
+        <div class="dt-kind"><span class="tag">${esc(ref.kind)}</span></div>
+        <h2>${esc(ref.label)}</h2>
+      </div>
+      <div class="resolved">
+        <span class="lbl" style="display:block;margin-bottom:4px">Not yet known in ${S.kt}</span>
+        <div class="big">no dated claim</div>
+        <p class="prov">Nothing datable has been asserted about this in
+        <b class="num">${S.kt}</b>. The page is not hiding it — in this year, nobody
+        had put a number on it.</p>
+        ${isFinite(first) ? `<p class="prov"><button class="edge-link" data-goto="${esc(ref.id)}"
+          style="padding:2px 0"><span><span class="who">Go to ${first}</span>
+          <span class="mech">the year the first dated claim arrives</span></span></button></p>` : ''}
+      </div>
+      ${pending.length ? `<div class="sect">
+        <span class="lbl">What is still to come · ${pending.length}</span>
+        ${pending.slice(0, 8).map(c => `<div class="claim pending" style="--cl:var(--rule)">
+          <p class="stmt">${esc(c.statement)}</p>
+          <p class="src">${esc(c.asserted_by)} — arrives in <span class="kt num">${c.knowledge_time}</span></p>
+        </div>`).join('')}
+      </div>` : ''}`;
+    return;
+  }
+
   if (!S.selection || !F.items[S.selection]) {
     const disp = F.visible.filter(i => i.res.disputed)
       .sort((a, b) => (b.res.oldest - b.res.youngest) - (a.res.oldest - a.res.youngest))

--- a/src/75_search.js
+++ b/src/75_search.js
@@ -25,8 +25,7 @@ const SEARCH_IDX = (() => {
       // The year resolve() can first place it, not the year anyone first said
       // anything about it - those differ, and the label has to match what
       // choosing the row will actually do.
-      first: claims.filter(c => !c._meta && isFinite(c.earth_time_start))
-        .reduce((m, c) => Math.min(m, c.knowledge_time), Infinity)
+      first: firstDatedYear(id)
     });
   }
   return out;
@@ -90,20 +89,31 @@ function closeResults() {
   elSearchNote.textContent = '';
 }
 
-/* Getting there is not enough: a result can be invisible because knowledge-time
-   is earlier than the claim, because its field of study is switched off, or
-   because another field is isolated. Choosing it opens whatever is in the way. */
-function chooseResult(id) {
-  if (!Object.prototype.hasOwnProperty.call(R.referents, id)) return;
-  const claims = R.byRef[id] || [];
+/** The year resolve() can first place a referent, or Infinity if it never can. */
+function firstDatedYear(id) {
+  return (R.byRef[id] || [])
+    /* Only claims that resolve() will actually count. Taking the minimum over
+       ALL claims picks up undated and _meta ones, so a referent whose earliest
+       DATED claim is 1953 but which carries a 1785 interpretation reported
+       "first claimed 1785" and then selected into an empty panel, because
+       resolve() returns null when nothing dated is live. Mirror its predicate. */
+    .filter(c => !c._meta && isFinite(c.earth_time_start))
+    .reduce((m, c) => Math.min(m, c.knowledge_time), Infinity);
+}
+
+/* Getting there is not enough: a referent can be invisible because
+   knowledge-time is earlier than the claim, because its field of study is
+   switched off, or because another field is isolated. This opens whatever is in
+   the way and returns the view that shows it — it mutates the filters, and
+   leaves the flying to the caller.
+
+   It exists because chooseResult did all of this and the panel's own Connections
+   links did none of it: a hop selected a referent with no mark on the globe or
+   the timeline and rendered a full panel for it anyway. */
+function revealReferent(id) {
+  if (!Object.prototype.hasOwnProperty.call(R.referents, id)) return null;
   let kt = S.kt;
-  /* Only claims that resolve() will actually count. Taking the minimum over ALL
-     claims picks up undated and _meta ones, so a referent whose earliest DATED
-     claim is 1953 but which carries a 1785 interpretation reported "first
-     claimed 1785" and then selected into an empty panel, because resolve()
-     returns null when nothing dated is live. Mirror its predicate exactly. */
-  const dated = claims.filter(c => !c._meta && isFinite(c.earth_time_start));
-  const first = dated.reduce((m, c) => Math.min(m, c.knowledge_time), Infinity);
+  const first = firstDatedYear(id);
   if (isFinite(first) && first > kt) kt = Math.min(KT_MAX, first);
 
   const res = resolve(id, kt, S.resolver);
@@ -111,9 +121,20 @@ function chooseResult(id) {
     if (S.focus && !res.subjects.includes(S.focus)) S.focus = null;
     if (!res.subjects.some(s => S.subjects.has(s))) for (const s of res.subjects) S.subjects.add(s);
   }
-  const t1 = res && isFinite(res.oldest)
-    ? Math.max(2000, Math.min(T_MAX, res.oldest * 1.7))
-    : S.win.t1;
+  /* Widen only when the target is actually outside the window. Widening every
+     time threw away a window someone had panned to, in order to "reveal"
+     something that was already inside it. */
+  let win = [S.win.t0, S.win.t1];
+  if (res && isFinite(res.oldest) &&
+      (res.oldest > S.win.t1 || res.youngest < S.win.t0)) {
+    win = [0, Math.max(2000, Math.min(T_MAX, res.oldest * 1.7))];
+  }
+  return { id, kt, win, res };
+}
+
+function chooseResult(id) {
+  const plan = revealReferent(id);
+  if (!plan) return;
   closeResults();
   elSearch.blur();
   /* On a phone the search box is in grid row 3 and the globe is row 1, so
@@ -125,7 +146,7 @@ function chooseResult(id) {
     try { stage.scrollIntoView({ block: 'start', behavior: RM.matches ? 'auto' : 'smooth' }); }
     catch (_) { stage.scrollIntoView(true); }
   }
-  flyTo({ id, kt, win: [0, t1] });
+  flyTo(plan);
 }
 
 let searchTimer = null;

--- a/src/80_boot.js
+++ b/src/80_boot.js
@@ -368,9 +368,16 @@ document.getElementById('subjects').addEventListener('dblclick', e => {
   changed();
 });
 
+/* A Connections link used to be a bare setSelection, which skipped every gate
+   chooseResult applies: with a subject switched off it selected a referent with
+   no mark on the globe or the timeline and rendered a full panel for it anyway.
+   Same helper, same guarantees. No stage scroll - the reader is looking at the
+   panel, and the panel rebuilds in place. */
 elDetail.addEventListener('click', e => {
   const b = e.target.closest('[data-goto]'); if (!b) return;
-  setSelection(b.dataset.goto);
+  const plan = revealReferent(b.dataset.goto);
+  if (!plan) return;
+  flyTo(plan);
   elDetail.scrollTop = 0;
 });
 
@@ -404,24 +411,65 @@ document.getElementById('btn-theme').addEventListener('click', () => {
 });
 matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => { readPalette(); markAll(); });
 
+/* The dialog carries role="dialog" aria-modal="true", which tells assistive
+   technology that everything outside it is hidden. Nothing made that true:
+   focus stayed on the opener - inside the part just declared hidden - thirty
+   background controls remained tabbable, and Tab walked straight out. inert
+   makes the claim honest, and the opener gets its focus back on the way out. */
 const diffwrap = document.getElementById('diffwrap');
-document.getElementById('btn-diff').addEventListener('click', e => {
-  const on = diffwrap.hidden;
+const btnDiff = document.getElementById('btn-diff');
+const diffA = document.getElementById('diff-a');
+const diffB = document.getElementById('diff-b');
+let diffOpener = null;
+
+function setDiffOpen(on) {
+  if (on === !diffwrap.hidden) return;
   diffwrap.hidden = !on;
-  e.currentTarget.setAttribute('aria-pressed', String(on));
-  if (on) { document.getElementById('diff-b').value = S.kt; renderDiff(); }
-});
-document.getElementById('diff-close').addEventListener('click', () => {
-  diffwrap.hidden = true;
-  document.getElementById('btn-diff').setAttribute('aria-pressed', 'false');
-});
-document.getElementById('diff-a').addEventListener('input', e => { S.ktA = +e.target.value || 1975; renderDiff(); });
-document.getElementById('diff-b').addEventListener('input', e => { setKt(+e.target.value || KT_MAX); renderDiff(); });
-document.addEventListener('keydown', e => {
-  if (e.key === 'Escape' && !diffwrap.hidden) {
-    diffwrap.hidden = true;
-    document.getElementById('btn-diff').setAttribute('aria-pressed', 'false');
+  btnDiff.setAttribute('aria-pressed', String(on));
+  for (const el of [document.querySelector('.app'), document.getElementById('tourbar')]) {
+    if (el) el.toggleAttribute('inert', on);
   }
+  if (on) {
+    diffOpener = document.activeElement;
+    diffB.value = S.kt;
+    diffA.value = S.ktA;
+    renderDiff();
+    diffA.focus();
+  } else {
+    const back = diffOpener && diffOpener.isConnected ? diffOpener : btnDiff;
+    diffOpener = null;
+    try { back.focus(); } catch (_) { /* it may have gone away; never fatal */ }
+  }
+}
+
+btnDiff.addEventListener('click', () => setDiffOpen(diffwrap.hidden));
+document.getElementById('diff-close').addEventListener('click', () => setDiffOpen(false));
+
+/* Take a year only once it is a complete one that exists on the rail. Clamping
+   per keystroke would snap the "1" on the way to "1850" to 1650 and make the
+   field unusable; `+value || dflt` was worse still, because 0 is falsy, so the
+   first character of "2000" silently jumped the comparison to 1975. The field
+   is reconciled with the state on change, so it can never be left showing a
+   year the page is not actually comparing. */
+function yearFromInput(el) {
+  const n = parseInt(el.value, 10);
+  return isFinite(n) && n >= KT_MIN && n <= KT_MAX ? n : null;
+}
+diffA.addEventListener('input', () => {
+  const n = yearFromInput(diffA);
+  if (n === null) return;
+  S.ktA = n; renderDiff();
+});
+diffB.addEventListener('input', () => {
+  const n = yearFromInput(diffB);
+  if (n === null) return;
+  setKt(n); renderDiff();
+});
+diffA.addEventListener('change', () => { diffA.value = S.ktA; renderDiff(); });
+diffB.addEventListener('change', () => { diffB.value = S.kt; renderDiff(); });
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape' && !diffwrap.hidden) setDiffOpen(false);
 });
 
 /* -------------------------------------------------------------- guided path */

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -438,6 +438,128 @@ def run(url, headed, report):
                      f"selection={page.evaluate('S.selection')!r} resolver={page.evaluate('S.resolver')!r}")
         report.check("a hostile hash raises no errors", not page_errors, " | ".join(page_errors[:2]))
 
+        # ------------------------------- 9. a link to something not known yet
+        # readHash validates s= against R.referents, which is right as far as it
+        # goes - but nothing checked the referent could be RESOLVED at the
+        # knowledge-time the same hash sets, so the panel fell through to
+        # "Nothing selected" with the selection still set and still in the URL.
+        page.goto("about:blank")
+        page.goto(url.split("#")[0] + "#k=1700&s=homo_sapiens", wait_until="load", timeout=45000)
+        page.wait_for_timeout(1200)
+        notyet = page.evaluate("""() => {
+          const t = (document.getElementById('detail').innerText || '').trim().toUpperCase();
+          return { sel: S.selection, kt: S.kt,
+                   resolvable: !!facts().items[S.selection],
+                   emptyState: t.startsWith('NOTHING SELECTED'),
+                   namesIt: t.includes('HOMO SAPIENS'),
+                   saysYear: t.includes('1700') };
+        }""")
+        report.check("a link to something not known yet explains itself",
+                     notyet["sel"] == "homo_sapiens" and not notyet["resolvable"]
+                     and not notyet["emptyState"] and notyet["namesIt"] and notyet["saysYear"],
+                     json.dumps(notyet))
+
+        # ------------------------ 10. a hop inside the panel lands in the open
+        # chooseResult clears a conflicting focus, re-enables the subject and
+        # advances knowledge-time before selecting. The panel's own Connections
+        # links did none of it, so a hop selected a referent with no mark on the
+        # globe or the timeline and rendered a full panel for it anyway.
+        page.goto("about:blank")
+        page.goto(url.split("#")[0], wait_until="load", timeout=45000)
+        page.wait_for_timeout(1400)
+        case = page.evaluate("""() => {
+          for (const sub of SUBJECTS) {
+            S.subjects = new Set([sub]); S.focus = null; setKt(2026);
+            S.selection = null; invalidate();
+            const F = facts();
+            for (const ed of F.allEdges) {
+              const a = F.items[ed.edge.source], b = F.items[ed.edge.target];
+              if (!a || !b) continue;
+              if (a.subjectOn && !b.subjectOn) return { sub, from: ed.edge.source, to: ed.edge.target };
+              if (b.subjectOn && !a.subjectOn) return { sub, from: ed.edge.target, to: ed.edge.source };
+            }
+          }
+          return null;
+        }""")
+        if report.check("there is a filter-hidden neighbour to hop to", case is not None,
+                        json.dumps(case)):
+            page.evaluate("""(c) => {
+              S.subjects = new Set([c.sub]); S.focus = null; setKt(2026);
+              setSelection(c.from); renderNow();
+            }""", case)
+            page.wait_for_timeout(300)
+            hopped = page.evaluate("""(c) => {
+              const b = document.querySelector('#detail [data-goto="' + c.to + '"]');
+              if (!b) return { clicked: false };
+              b.click();
+              return { clicked: true };
+            }""", case)
+            page.wait_for_timeout(1500)
+            landed = page.evaluate("""() => {
+              const it = facts().items[S.selection];
+              return { sel: S.selection, visible: !!(it && it.visible),
+                       onScreen: HIT.some(h => h.id === S.selection)
+                              || CHIT.some(h => h.id === S.selection) };
+            }""")
+            report.check("a hop inside the panel lands on something you can see",
+                         hopped["clicked"] and landed["sel"] == case["to"]
+                         and landed["visible"] and landed["onScreen"],
+                         json.dumps(landed))
+
+        # --------------- 11. revealing something already in view keeps the view
+        # chooseResult widened to [0, oldest*1.7] unconditionally, throwing away
+        # a window someone had panned to in order to reveal a thing that was
+        # never hidden.
+        kept = page.evaluate("""() => {
+          setKt(2026); S.subjects = new Set(SUBJECTS); S.focus = null;
+          setWindow(0, 1.0e8); renderNow();
+          const before = [Math.round(S.win.t0), Math.round(S.win.t1)];
+          const r = resolve('kpg_extinction', S.kt, S.resolver);
+          const inside = r.oldest <= S.win.t1 && r.youngest >= S.win.t0;
+          chooseResult('kpg_extinction');
+          return { before, inside,
+                   to: TW ? [Math.round(TW.to.t0), Math.round(TW.to.t1)] : before };
+        }""")
+        report.check("revealing something already on screen keeps the window",
+                     kept["inside"] and kept["to"] == kept["before"], json.dumps(kept))
+
+        # ------------------------- 12. Compare eras is as modal as it says it is
+        page.evaluate("TW = null; S.selection = null; changed(); renderNow();")
+        page.wait_for_timeout(200)
+        page.click("#btn-diff")
+        page.wait_for_timeout(400)
+        modal = page.evaluate("""() => ({
+          focusInside: document.getElementById('diffwrap').contains(document.activeElement),
+          appInert: document.querySelector('.app').hasAttribute('inert')
+        })""")
+        for _ in range(10):
+            page.keyboard.press("Tab")
+        modal["stillInside"] = page.evaluate(
+            "document.getElementById('diffwrap').contains(document.activeElement)")
+        report.check("Compare eras keeps focus in the dialog it declares modal",
+                     modal["focusInside"] and modal["appInert"] and modal["stillInside"],
+                     json.dumps(modal))
+
+        # ---------------------------- 13. the year inputs stay on the rail
+        # `+value || 1975` accepted 9, 3000 and -5 into S.ktA and drove resolve()
+        # and the dialog title with them; and 0 is falsy, so the first character
+        # of "2000" silently jumped the comparison to 1975.
+        years = []
+        for typed in ("9", "0", "3000", "-5"):
+            page.fill("#diff-a", typed)
+            page.wait_for_timeout(220)
+            years.append(page.evaluate("S.ktA"))
+        report.check("the compare-eras years stay on the knowledge rail",
+                     all(1650 <= y <= 2026 for y in years), json.dumps(years))
+        page.keyboard.press("Escape")
+        page.wait_for_timeout(250)
+        report.check("Escape gives focus back to the button that opened it",
+                     page.evaluate("document.activeElement.id") == "btn-diff",
+                     page.evaluate("document.activeElement.id || document.activeElement.tagName"))
+
+        report.check("no page errors across the whole desktop run", not page_errors,
+                     " | ".join(page_errors[:2]))
+
         browser.close()
 
 


### PR DESCRIPTION
Wave 3 of the bug audit. Five bugs, all about arriving at a referent and finding nothing there.

Closes #11, closes #12, closes #13. Implements item 4 and the dialog half of item 10 of `docs/ux-review-2026-08-03.md`.

## "Nothing selected", while something is selected

`readHash` validates `s=` against `R.referents` with a proper own-property test, but nothing checks the referent can be *resolved* at the knowledge-time the same hash sets.

```
#k=1700&s=homo_sapiens
S.selection   'homo_sapiens'
items[sel]    undefined         <- resolve() returns null in 1700
detail panel  "Nothing selected. Click any marker…"
location.hash '#k=1700&…&s=homo_sapiens'
```

A visitor who followed a link naming a subject is told nothing is selected, while the URL in front of them says otherwise, with no way out but Escape.

This is not an error state — it is the thesis. In 1700 nobody had put a number on *Homo sapiens*, `resolve()` knows that, and the panel was throwing it away for a generic instruction. It now names the referent, says nothing datable is claimed about it in that year, offers the year the first dated claim arrives as a control, and lists what is still to come.

## A hop that lands nowhere

`chooseResult` advances knowledge-time, clears a conflicting focus, and re-enables the subject before selecting. A **Connections** link in the panel was `setSelection(id)` and nothing else — under a comment forty lines away stating the rule it violates.

Reproduced with the filter on geology, hopping Cambrian explosion → first vertebrates:

| | before | after |
|---|---|---|
| `items[id].subjectOn` | false | true |
| `items[id].visible` | false | true |
| mark in `HIT` / `CHIT` | none | present |

A full detail panel for a referent with no mark anywhere on the page. Both callers now go through one `revealReferent`.

## …and the one place that did the work did a piece of it wrong

`chooseResult` widened to `[0, oldest * 1.7]` unconditionally. Pan to a 100 Myr window, search for something already inside it, and the window is replaced to "reveal" a thing that was never hidden:

```
before [0, 100000000]   target inside: true   tween target [0, 112291800]
```

Now gated on the target actually being outside the window.

## Compare eras is not modal

```
document.activeElement        'btn-diff'    <- the opener, behind the dialog
focus inside the dialog       false
.app has inert                false
background controls tabbable  30
after 8 Tabs, focus inside    false
```

`aria-modal="true"` tells assistive technology the rest of the page is hidden. The rest of the page is now `inert`, focus moves in on open and returns to the opener on close.

## Its year inputs accept anything

`+e.target.value || 1975`:

| typed | `S.ktA` | title |
|---|---|---|
| `9` | 9 | What changed between 9 and 2026 |
| `0` | **1975** | — `0` is falsy, so typing `2000` jumps mid-keystroke |
| `3000` | 3000 | What changed between 2026 and 3000 |
| `-5` | −5 | What changed between −5 and 2026 |

A year is now taken only once it is a complete one that exists on the rail — clamping per keystroke would snap the `1` on the way to `1850` and make the field unusable — and the field is reconciled with the state on `change`.

## Verification

```
python3 tools/validate_graph.py                 ERRORS (0)
python3 tools/check_no_local_paths.py --all     clean
python3 tools/build.py                          59/59 checks passed
```

Six new checks, each confirmed against the bug reintroduced:

```
[FAIL] a link to something not known yet explains itself      emptyState: true, namesIt: false
[FAIL] a hop inside the panel lands on something you can see  visible: false, onScreen: false
[FAIL] revealing something already on screen keeps the window before [0,1e8] -> to [0,112291800]
[FAIL] Compare eras keeps focus in the dialog it declares modal  focusInside: false, appInert: false
[FAIL] the compare-eras years stay on the knowledge rail       [9, 1975, 3000, -5]
[FAIL] Escape gives focus back to the button that opened it    BODY
53/59 checks passed
```

and 59/59 with the fixes restored.

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_