### PR TITLE
Let a swipe up scroll the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,10 @@ Then it opens a second context at 390x844 with real touch and asks the phone
 build the questions the desktop one cannot: can a finger reach every control on
 the stage, does tapping a marker put its panel where you can see it, does
 choosing a search result fly a globe that is on screen, is the globe's focus
-ring inside its own clipping box. 61 checks, wired into `build.py`, exits
-non-zero.
+ring inside its own clipping box, does a swipe up scroll the page rather than
+rewrite the view — and, because that fix trades something away, do a horizontal
+drag, a tap on the rail and a two-finger pinch all still do what they did.
+67 checks, wired into `build.py`, exits non-zero.
 
 It exists because this project lost an entire build to a boot failure that
 nothing detected: a legend swatch read the wrong palette key, `undefined` reached
@@ -218,9 +220,12 @@ for the same numbers.
   of the smoke test. A hop inside the panel now goes through the same gate
   `chooseResult` does — and that gate no longer throws away a window someone
   panned to in order to reveal something already inside it — and `Compare eras`
-  now makes the rest of the page `inert` instead of only claiming to. Still
-  open: the scroll-versus-rotate conflict on touch, light-mode contrast on the
-  stage overlays, and the rest. See [`docs/ux-review-2026-08-03.md`](docs/ux-review-2026-08-03.md),
+  now makes the rest of the page `inert` instead of only claiming to. A swipe up
+  scrolls the page instead of slamming the globe to the pole or moving
+  knowledge-time by forty-seven years — which costs the rail's vertical
+  drag-scrub on touch, deliberately: tap-to-set, the arrow keys and `Home`/`End`
+  all remain, and the globe still tilts under two fingers. Still open:
+  light-mode contrast on the stage overlays, and the rest. See [`docs/ux-review-2026-08-03.md`](docs/ux-review-2026-08-03.md),
   which covers this site and its sibling together.
 
 ## Two deliberate departures

--- a/artifact.html
+++ b/artifact.html
@@ -459,6 +459,26 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
   .detail { overflow: visible; }
 }
 
+/* A one-finger vertical swipe has to scroll the page. With touch-action:none on
+   all three surfaces it never did: at 390x844 the page is 1572px tall in an
+   870px viewport, and a 240px upward swipe took the globe from phi 12 to -89,
+   or knowledge-time from 2026 to 1979, with scrollY still 0 — while on the
+   timeline, whose pan reads only clientX, it did nothing at all. That is 718px
+   of an 870px first screen that refuses to scroll.
+
+   pan-y hands the vertical axis back to the browser and keeps everything
+   horizontal-dominant. The browser fires pointercancel when it takes a gesture
+   over, which the pointer bookkeeping in src/80_boot.js already handles.
+
+   The trade, deliberately: kSet reads only clientY, so the knowledge rail's
+   vertical drag-scrub is gone on touch. Tap-to-set stays, so do Home/End and
+   the arrow keys, and an unrequested 47-year jump is worse than losing a scrub.
+   Vertical rotation of the globe survives through the two-finger path, whose
+   midpoint handler already moves both lam and phi. */
+@media (pointer: coarse) {
+  #globe, #krailcv, #chroncv { touch-action: pan-y; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   * { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; }
 }
@@ -2961,7 +2981,14 @@ gcv.addEventListener('pointermove', e => {
     gMoved += Math.abs(dx) + Math.abs(dy);
     const k = 180 / (GR * Math.PI) * 1.1;
     S.rot.lam += dx * k;
-    S.rot.phi = Math.max(-89, Math.min(89, S.rot.phi + dy * k));
+    /* One finger does not own the vertical axis - the page does, so that a
+       swipe up scrolls. touch-action:pan-y is not enough on its own: the moves
+       delivered before the browser commits to scrolling still tilted the globe,
+       12 degrees to 2 in a single swipe. Two fingers rotate in both axes; the
+       pinch handler moves lam and phi together from the midpoint. */
+    if (e.pointerType !== 'touch') {
+      S.rot.phi = Math.max(-89, Math.min(89, S.rot.phi + dy * k));
+    }
     gVel.push({ dx, dy, t: performance.now() });
     if (gVel.length > 5) gVel.shift();
     gDrag = { x: e.clientX, y: e.clientY, t: performance.now() };
@@ -3163,14 +3190,37 @@ document.getElementById('presets').addEventListener('click', e => {
 });
 
 /* ------------------------------------------------------------------- krail */
-let kDrag = false;
+/* The rail scrubs vertically, which on a touchscreen is the same gesture as
+   scrolling the page. It used to win that fight from the first pointermove: a
+   240px swipe moved knowledge-time from 2026 to 1979 with scrollY still 0. And
+   acting on pointerdown is no better - a finger landing here on its way past is
+   not a request to jump two centuries.
+
+   So on touch the rail is tap-to-set: nothing happens until the finger lifts,
+   and only if it barely moved. Under a mouse or a pen, where the press IS the
+   gesture and there is no scroll to lose, the drag-scrub is untouched. */
+let kDrag = false, kTouch = false, kMoved = 0, kDownY = 0;
+const K_TAP_SLOP = 8;
 function kSet(e) {
   const r = kcv.getBoundingClientRect();
   setKt(yToKt(e.clientY - r.top));
 }
-kcv.addEventListener('pointerdown', e => { try { kcv.setPointerCapture(e.pointerId); } catch (_) {} kDrag = true; stopReplay(); kSet(e); });
-kcv.addEventListener('pointermove', e => { if (kDrag) kSet(e); });
-kcv.addEventListener('pointerup', () => { kDrag = false; });
+kcv.addEventListener('pointerdown', e => {
+  try { kcv.setPointerCapture(e.pointerId); } catch (_) {}
+  stopReplay();
+  kDrag = true; kTouch = e.pointerType === 'touch'; kMoved = 0; kDownY = e.clientY;
+  if (!kTouch) kSet(e);
+});
+kcv.addEventListener('pointermove', e => {
+  if (!kDrag) return;
+  kMoved = Math.max(kMoved, Math.abs(e.clientY - kDownY));
+  if (kTouch) return;
+  kSet(e);
+});
+kcv.addEventListener('pointerup', e => {
+  if (kDrag && kTouch && kMoved < K_TAP_SLOP) kSet(e);
+  kDrag = false;
+});
 kcv.addEventListener('pointercancel', () => { kDrag = false; });
 kcv.addEventListener('keydown', e => {
   const step = e.shiftKey ? 25 : 1;

--- a/earth-x-time.html
+++ b/earth-x-time.html
@@ -464,6 +464,26 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
   .detail { overflow: visible; }
 }
 
+/* A one-finger vertical swipe has to scroll the page. With touch-action:none on
+   all three surfaces it never did: at 390x844 the page is 1572px tall in an
+   870px viewport, and a 240px upward swipe took the globe from phi 12 to -89,
+   or knowledge-time from 2026 to 1979, with scrollY still 0 — while on the
+   timeline, whose pan reads only clientX, it did nothing at all. That is 718px
+   of an 870px first screen that refuses to scroll.
+
+   pan-y hands the vertical axis back to the browser and keeps everything
+   horizontal-dominant. The browser fires pointercancel when it takes a gesture
+   over, which the pointer bookkeeping in src/80_boot.js already handles.
+
+   The trade, deliberately: kSet reads only clientY, so the knowledge rail's
+   vertical drag-scrub is gone on touch. Tap-to-set stays, so do Home/End and
+   the arrow keys, and an unrequested 47-year jump is worse than losing a scrub.
+   Vertical rotation of the globe survives through the two-finger path, whose
+   midpoint handler already moves both lam and phi. */
+@media (pointer: coarse) {
+  #globe, #krailcv, #chroncv { touch-action: pan-y; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   * { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; }
 }
@@ -2968,7 +2988,14 @@ gcv.addEventListener('pointermove', e => {
     gMoved += Math.abs(dx) + Math.abs(dy);
     const k = 180 / (GR * Math.PI) * 1.1;
     S.rot.lam += dx * k;
-    S.rot.phi = Math.max(-89, Math.min(89, S.rot.phi + dy * k));
+    /* One finger does not own the vertical axis - the page does, so that a
+       swipe up scrolls. touch-action:pan-y is not enough on its own: the moves
+       delivered before the browser commits to scrolling still tilted the globe,
+       12 degrees to 2 in a single swipe. Two fingers rotate in both axes; the
+       pinch handler moves lam and phi together from the midpoint. */
+    if (e.pointerType !== 'touch') {
+      S.rot.phi = Math.max(-89, Math.min(89, S.rot.phi + dy * k));
+    }
     gVel.push({ dx, dy, t: performance.now() });
     if (gVel.length > 5) gVel.shift();
     gDrag = { x: e.clientX, y: e.clientY, t: performance.now() };
@@ -3170,14 +3197,37 @@ document.getElementById('presets').addEventListener('click', e => {
 });
 
 /* ------------------------------------------------------------------- krail */
-let kDrag = false;
+/* The rail scrubs vertically, which on a touchscreen is the same gesture as
+   scrolling the page. It used to win that fight from the first pointermove: a
+   240px swipe moved knowledge-time from 2026 to 1979 with scrollY still 0. And
+   acting on pointerdown is no better - a finger landing here on its way past is
+   not a request to jump two centuries.
+
+   So on touch the rail is tap-to-set: nothing happens until the finger lifts,
+   and only if it barely moved. Under a mouse or a pen, where the press IS the
+   gesture and there is no scroll to lose, the drag-scrub is untouched. */
+let kDrag = false, kTouch = false, kMoved = 0, kDownY = 0;
+const K_TAP_SLOP = 8;
 function kSet(e) {
   const r = kcv.getBoundingClientRect();
   setKt(yToKt(e.clientY - r.top));
 }
-kcv.addEventListener('pointerdown', e => { try { kcv.setPointerCapture(e.pointerId); } catch (_) {} kDrag = true; stopReplay(); kSet(e); });
-kcv.addEventListener('pointermove', e => { if (kDrag) kSet(e); });
-kcv.addEventListener('pointerup', () => { kDrag = false; });
+kcv.addEventListener('pointerdown', e => {
+  try { kcv.setPointerCapture(e.pointerId); } catch (_) {}
+  stopReplay();
+  kDrag = true; kTouch = e.pointerType === 'touch'; kMoved = 0; kDownY = e.clientY;
+  if (!kTouch) kSet(e);
+});
+kcv.addEventListener('pointermove', e => {
+  if (!kDrag) return;
+  kMoved = Math.max(kMoved, Math.abs(e.clientY - kDownY));
+  if (kTouch) return;
+  kSet(e);
+});
+kcv.addEventListener('pointerup', e => {
+  if (kDrag && kTouch && kMoved < K_TAP_SLOP) kSet(e);
+  kDrag = false;
+});
 kcv.addEventListener('pointercancel', () => { kDrag = false; });
 kcv.addEventListener('keydown', e => {
   const step = e.shiftKey ? 25 : 1;

--- a/index.html
+++ b/index.html
@@ -464,6 +464,26 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
   .detail { overflow: visible; }
 }
 
+/* A one-finger vertical swipe has to scroll the page. With touch-action:none on
+   all three surfaces it never did: at 390x844 the page is 1572px tall in an
+   870px viewport, and a 240px upward swipe took the globe from phi 12 to -89,
+   or knowledge-time from 2026 to 1979, with scrollY still 0 — while on the
+   timeline, whose pan reads only clientX, it did nothing at all. That is 718px
+   of an 870px first screen that refuses to scroll.
+
+   pan-y hands the vertical axis back to the browser and keeps everything
+   horizontal-dominant. The browser fires pointercancel when it takes a gesture
+   over, which the pointer bookkeeping in src/80_boot.js already handles.
+
+   The trade, deliberately: kSet reads only clientY, so the knowledge rail's
+   vertical drag-scrub is gone on touch. Tap-to-set stays, so do Home/End and
+   the arrow keys, and an unrequested 47-year jump is worse than losing a scrub.
+   Vertical rotation of the globe survives through the two-finger path, whose
+   midpoint handler already moves both lam and phi. */
+@media (pointer: coarse) {
+  #globe, #krailcv, #chroncv { touch-action: pan-y; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   * { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; }
 }
@@ -2968,7 +2988,14 @@ gcv.addEventListener('pointermove', e => {
     gMoved += Math.abs(dx) + Math.abs(dy);
     const k = 180 / (GR * Math.PI) * 1.1;
     S.rot.lam += dx * k;
-    S.rot.phi = Math.max(-89, Math.min(89, S.rot.phi + dy * k));
+    /* One finger does not own the vertical axis - the page does, so that a
+       swipe up scrolls. touch-action:pan-y is not enough on its own: the moves
+       delivered before the browser commits to scrolling still tilted the globe,
+       12 degrees to 2 in a single swipe. Two fingers rotate in both axes; the
+       pinch handler moves lam and phi together from the midpoint. */
+    if (e.pointerType !== 'touch') {
+      S.rot.phi = Math.max(-89, Math.min(89, S.rot.phi + dy * k));
+    }
     gVel.push({ dx, dy, t: performance.now() });
     if (gVel.length > 5) gVel.shift();
     gDrag = { x: e.clientX, y: e.clientY, t: performance.now() };
@@ -3170,14 +3197,37 @@ document.getElementById('presets').addEventListener('click', e => {
 });
 
 /* ------------------------------------------------------------------- krail */
-let kDrag = false;
+/* The rail scrubs vertically, which on a touchscreen is the same gesture as
+   scrolling the page. It used to win that fight from the first pointermove: a
+   240px swipe moved knowledge-time from 2026 to 1979 with scrollY still 0. And
+   acting on pointerdown is no better - a finger landing here on its way past is
+   not a request to jump two centuries.
+
+   So on touch the rail is tap-to-set: nothing happens until the finger lifts,
+   and only if it barely moved. Under a mouse or a pen, where the press IS the
+   gesture and there is no scroll to lose, the drag-scrub is untouched. */
+let kDrag = false, kTouch = false, kMoved = 0, kDownY = 0;
+const K_TAP_SLOP = 8;
 function kSet(e) {
   const r = kcv.getBoundingClientRect();
   setKt(yToKt(e.clientY - r.top));
 }
-kcv.addEventListener('pointerdown', e => { try { kcv.setPointerCapture(e.pointerId); } catch (_) {} kDrag = true; stopReplay(); kSet(e); });
-kcv.addEventListener('pointermove', e => { if (kDrag) kSet(e); });
-kcv.addEventListener('pointerup', () => { kDrag = false; });
+kcv.addEventListener('pointerdown', e => {
+  try { kcv.setPointerCapture(e.pointerId); } catch (_) {}
+  stopReplay();
+  kDrag = true; kTouch = e.pointerType === 'touch'; kMoved = 0; kDownY = e.clientY;
+  if (!kTouch) kSet(e);
+});
+kcv.addEventListener('pointermove', e => {
+  if (!kDrag) return;
+  kMoved = Math.max(kMoved, Math.abs(e.clientY - kDownY));
+  if (kTouch) return;
+  kSet(e);
+});
+kcv.addEventListener('pointerup', e => {
+  if (kDrag && kTouch && kMoved < K_TAP_SLOP) kSet(e);
+  kDrag = false;
+});
 kcv.addEventListener('pointercancel', () => { kDrag = false; });
 kcv.addEventListener('keydown', e => {
   const step = e.shiftKey ? 25 : 1;

--- a/src/00_head.html
+++ b/src/00_head.html
@@ -457,6 +457,26 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
   .detail { overflow: visible; }
 }
 
+/* A one-finger vertical swipe has to scroll the page. With touch-action:none on
+   all three surfaces it never did: at 390x844 the page is 1572px tall in an
+   870px viewport, and a 240px upward swipe took the globe from phi 12 to -89,
+   or knowledge-time from 2026 to 1979, with scrollY still 0 — while on the
+   timeline, whose pan reads only clientX, it did nothing at all. That is 718px
+   of an 870px first screen that refuses to scroll.
+
+   pan-y hands the vertical axis back to the browser and keeps everything
+   horizontal-dominant. The browser fires pointercancel when it takes a gesture
+   over, which the pointer bookkeeping in src/80_boot.js already handles.
+
+   The trade, deliberately: kSet reads only clientY, so the knowledge rail's
+   vertical drag-scrub is gone on touch. Tap-to-set stays, so do Home/End and
+   the arrow keys, and an unrequested 47-year jump is worse than losing a scrub.
+   Vertical rotation of the globe survives through the two-finger path, whose
+   midpoint handler already moves both lam and phi. */
+@media (pointer: coarse) {
+  #globe, #krailcv, #chroncv { touch-action: pan-y; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   * { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; }
 }

--- a/src/80_boot.js
+++ b/src/80_boot.js
@@ -119,7 +119,14 @@ gcv.addEventListener('pointermove', e => {
     gMoved += Math.abs(dx) + Math.abs(dy);
     const k = 180 / (GR * Math.PI) * 1.1;
     S.rot.lam += dx * k;
-    S.rot.phi = Math.max(-89, Math.min(89, S.rot.phi + dy * k));
+    /* One finger does not own the vertical axis - the page does, so that a
+       swipe up scrolls. touch-action:pan-y is not enough on its own: the moves
+       delivered before the browser commits to scrolling still tilted the globe,
+       12 degrees to 2 in a single swipe. Two fingers rotate in both axes; the
+       pinch handler moves lam and phi together from the midpoint. */
+    if (e.pointerType !== 'touch') {
+      S.rot.phi = Math.max(-89, Math.min(89, S.rot.phi + dy * k));
+    }
     gVel.push({ dx, dy, t: performance.now() });
     if (gVel.length > 5) gVel.shift();
     gDrag = { x: e.clientX, y: e.clientY, t: performance.now() };
@@ -321,14 +328,37 @@ document.getElementById('presets').addEventListener('click', e => {
 });
 
 /* ------------------------------------------------------------------- krail */
-let kDrag = false;
+/* The rail scrubs vertically, which on a touchscreen is the same gesture as
+   scrolling the page. It used to win that fight from the first pointermove: a
+   240px swipe moved knowledge-time from 2026 to 1979 with scrollY still 0. And
+   acting on pointerdown is no better - a finger landing here on its way past is
+   not a request to jump two centuries.
+
+   So on touch the rail is tap-to-set: nothing happens until the finger lifts,
+   and only if it barely moved. Under a mouse or a pen, where the press IS the
+   gesture and there is no scroll to lose, the drag-scrub is untouched. */
+let kDrag = false, kTouch = false, kMoved = 0, kDownY = 0;
+const K_TAP_SLOP = 8;
 function kSet(e) {
   const r = kcv.getBoundingClientRect();
   setKt(yToKt(e.clientY - r.top));
 }
-kcv.addEventListener('pointerdown', e => { try { kcv.setPointerCapture(e.pointerId); } catch (_) {} kDrag = true; stopReplay(); kSet(e); });
-kcv.addEventListener('pointermove', e => { if (kDrag) kSet(e); });
-kcv.addEventListener('pointerup', () => { kDrag = false; });
+kcv.addEventListener('pointerdown', e => {
+  try { kcv.setPointerCapture(e.pointerId); } catch (_) {}
+  stopReplay();
+  kDrag = true; kTouch = e.pointerType === 'touch'; kMoved = 0; kDownY = e.clientY;
+  if (!kTouch) kSet(e);
+});
+kcv.addEventListener('pointermove', e => {
+  if (!kDrag) return;
+  kMoved = Math.max(kMoved, Math.abs(e.clientY - kDownY));
+  if (kTouch) return;
+  kSet(e);
+});
+kcv.addEventListener('pointerup', e => {
+  if (kDrag && kTouch && kMoved < K_TAP_SLOP) kSet(e);
+  kDrag = false;
+});
 kcv.addEventListener('pointercancel', () => { kDrag = false; });
 kcv.addEventListener('keydown', e => {
   const step = e.shiftKey ? 25 : 1;

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -689,6 +689,91 @@ def run_mobile(url, headed, report):
                      or (ring["offset"] or "").startswith("-"),
                      json.dumps(ring)[:140])
 
+        # ------------- a swipe up scrolls the page, it does not rewrite the view
+        # All three surfaces carried touch-action:none, so the browser never got
+        # the gesture: a 240px upward swipe took the globe from phi 12 to -89,
+        # or knowledge-time from 2026 to 1979, with scrollY still 0 - and on the
+        # timeline, whose pan reads only clientX, it did nothing at all. That was
+        # 718px of an 870px first screen that refused to scroll.
+        cdpm = ctx.new_cdp_session(page)
+
+        def mtouch(kind, points):
+            cdpm.send("Input.dispatchTouchEvent", {
+                "type": kind,
+                "touchPoints": [{"x": x, "y": y, "id": i} for i, (x, y) in enumerate(points)]})
+
+        def swipe_up(x, y, dist=240, steps=12):
+            mtouch("touchStart", [(x, y)])
+            for i in range(1, steps + 1):
+                mtouch("touchMove", [(x, y - dist * i / steps)])
+                page.wait_for_timeout(8)
+            mtouch("touchEnd", [])
+            page.wait_for_timeout(450)
+
+        for name, sel, probe in (
+                ("globe", "#globe", "S.rot.phi"),
+                ("knowledge rail", "#krailcv", "S.kt"),
+                ("timeline", "#chroncv", "S.win.t1")):
+            page.evaluate("""(s) => {
+              scrollTo(0, 0); setKt(KT_MAX); S.rot.lam = 30; S.rot.phi = 12;
+              setWindow(0, 4.6e9); TW = null; changed(); renderNow();
+            }""", sel)
+            page.wait_for_timeout(250)
+            spot = page.evaluate("""(s) => {
+              const r = document.querySelector(s).getBoundingClientRect();
+              return { x: r.left + r.width * 0.5, y: r.top + r.height * 0.6 };
+            }""", sel)
+            before = page.evaluate(probe)
+            swipe_up(spot["x"], spot["y"])
+            after = page.evaluate(probe)
+            scrolled = page.evaluate("scrollY")
+            report.check(f"a swipe on the {name} scrolls the page and leaves the view alone",
+                         scrolled > 40 and after == before,
+                         f"scrollY {scrolled}   {probe} {before} -> {after}")
+
+        # ------------------- and the gestures that are the point still work
+        page.evaluate("scrollTo(0, 0); S.rot.lam = 30; TW = null; changed(); renderNow();")
+        page.wait_for_timeout(250)
+        gspot = page.evaluate("""() => {
+          const r = document.getElementById('globe').getBoundingClientRect();
+          return { cx: r.left + r.width / 2, cy: r.top + r.height / 2 };
+        }""")
+        lam0 = page.evaluate("S.rot.lam")
+        mtouch("touchStart", [(gspot["cx"] - 90, gspot["cy"])])
+        for i in range(1, 13):
+            mtouch("touchMove", [(gspot["cx"] - 90 + 15 * i, gspot["cy"])])
+            page.wait_for_timeout(8)
+        mtouch("touchEnd", [])
+        page.wait_for_timeout(350)
+        report.check("a horizontal drag still rotates the globe on touch",
+                     abs(page.evaluate("S.rot.lam") - lam0) > 5 and page.evaluate("scrollY") == 0,
+                     f"lam {lam0} -> {page.evaluate('S.rot.lam'):.1f}")
+
+        page.evaluate("scrollTo(0, 0); setKt(KT_MAX); renderNow();")
+        page.wait_for_timeout(200)
+        kspot = page.evaluate("""() => {
+          const r = document.getElementById('krailcv').getBoundingClientRect();
+          return { x: r.left + r.width * 0.6, y: r.top + r.height * 0.7 };
+        }""")
+        page.touchscreen.tap(kspot["x"], kspot["y"])
+        page.wait_for_timeout(400)
+        report.check("a tap still sets the year on the rail",
+                     page.evaluate("S.kt") < 2026, f"kt -> {page.evaluate('S.kt')}")
+
+        page.evaluate("scrollTo(0, 0); setKt(KT_MAX); setZoom(1.0); S.rot.phi = 12; renderNow();")
+        page.wait_for_timeout(200)
+        z0m = page.evaluate("ZOOMF")
+        mtouch("touchStart", [(gspot["cx"] - 30, gspot["cy"]), (gspot["cx"] + 30, gspot["cy"])])
+        for d in (50, 70, 90, 110):
+            mtouch("touchMove", [(gspot["cx"] - d, gspot["cy"]), (gspot["cx"] + d, gspot["cy"])])
+            page.wait_for_timeout(16)
+        mtouch("touchEnd", [(gspot["cx"] + 110, gspot["cy"])])
+        mtouch("touchEnd", [])
+        page.wait_for_timeout(350)
+        report.check("two fingers still zoom the globe on touch",
+                     page.evaluate("ZOOMF") - z0m > 0.2 and page.evaluate("PTRS.size") == 0,
+                     f"ZOOMF {z0m:.2f} -> {page.evaluate('ZOOMF'):.2f}")
+
         report.check("no page errors on the phone build", not page_errors,
                      " | ".join(page_errors[:2]))
         browser.close()


### PR DESCRIPTION
Wave 5 of the bug audit. Closes #17. Implements item 2 of `docs/ux-review-2026-08-03.md`, the last of its phone blockers.

## What was wrong

All three interactive surfaces carried `touch-action: none`, so the browser never got a chance at a one-finger gesture. At 390×844 the page is 1572 px tall in an 870 px viewport, and a 240 px upward swipe — the first thing anyone does on any page — did this instead:

| surface | result | `scrollY` |
|---|---|---|
| `#globe` | `S.rot.phi` **12 → −89**, clamped at the south pole | 0 |
| `#krailcv` | `S.kt` **2026 → 1979** | 0 |
| `#chroncv` | nothing at all | 0 |

The stage is 388 px and the timeline is 330 px, so **718 px of an 870 px first screen refused to scroll**. That third row is the one the review did not list and the worst-behaved of the three: the timeline's pan reads only `clientX`, so a vertical swipe was swallowed whole — no scroll, no state, no feedback.

## Why the CSS alone is not the fix

`touch-action: pan-y` under `(pointer: coarse)` hands the vertical axis back to the browser, and the page does then scroll. But the moves delivered *before* the browser commits to scrolling still land in the handlers:

```
with pan-y only:  globe phi 12 -> 2.4   (scrollY 268)
                  rail  kt 2026 -> 1831 (scrollY 225)
```

So the handlers yield the axis too. One finger on the globe owns longitude only. The rail is tap-to-set on touch — nothing happens until the finger lifts, and only if it barely moved, because acting on `pointerdown` is no better: a finger landing there on its way past is not a request to jump two centuries.

Under a mouse or a pen, where the press *is* the gesture and there is no scroll to lose, both paths are untouched.

```
after:  globe phi 12 -> 12    (scrollY 199)
        rail  kt 2026 -> 2026 (scrollY 225)
        chron t1 unchanged    (scrollY 225)
```

## The trade

Stated rather than discovered: `kSet` reads only `e.clientY`, so the knowledge rail's **vertical drag-scrub is gone on touch**. Tap-to-set stays, so do `Home`, `End` and the arrow keys, and the globe still tilts under two fingers — the pinch handler already moves `lam` and `phi` together from the midpoint.

## Verification

Seven new checks. Three assert the swipe scrolls and leaves the view alone; four assert the gestures that are the point still work, because a fix that trades something away has to say what survived.

Without the fix:

```
[FAIL] a swipe on the globe scrolls the page and leaves the view alone   scrollY 0  S.rot.phi 12 -> -89
[FAIL] a swipe on the knowledge rail scrolls the page and leaves the view alone   scrollY 0  S.kt 2026 -> 1972
[FAIL] a swipe on the timeline scrolls the page and leaves the view alone   scrollY 0
64/67 checks passed
```

with the four survivors green throughout, and 67/67 restored:

```
[PASS] a horizontal drag still rotates the globe on touch   lam 30 -> 199.6
[PASS] a tap still sets the year on the rail   kt -> 1739
[PASS] two fingers still zoom the globe on touch   ZOOMF 1.00 -> 3.20
[PASS] tapping a marker brings its panel into view
```

All three gates clean:

```
python3 tools/validate_graph.py                 ERRORS (0)
python3 tools/check_no_local_paths.py --all     clean
python3 tools/build.py                          67/67 checks passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_