### PR TITLE
Make every small string readable, and measure it rather than eyeball it

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,12 @@ choosing a search result fly a globe that is on screen, is the globe's focus
 ring inside its own clipping box, does a swipe up scroll the page rather than
 rewrite the view — and, because that fix trades something away, do a horizontal
 drag, a tap on the rail and a two-finger pinch all still do what they did.
-67 checks, wired into `build.py`, exits non-zero.
+
+Then it loads the page once more in each theme and measures the contrast of
+every small explanatory string against its real background — photographing the
+painted pixels behind the stage overlays, because a computed `background-color`
+cannot see the gradient they sit on. 69 checks, wired into `build.py`, exits
+non-zero.
 
 It exists because this project lost an entire build to a boot failure that
 nothing detected: a legend swatch read the wrong palette key, `undefined` reached
@@ -224,8 +229,12 @@ for the same numbers.
   scrolls the page instead of slamming the globe to the pole or moving
   knowledge-time by forty-seven years — which costs the rail's vertical
   drag-scrub on touch, deliberately: tap-to-set, the arrow keys and `Home`/`End`
-  all remain, and the globe still tilts under two fingers. Still open:
-  light-mode contrast on the stage overlays, and the rest. See [`docs/ux-review-2026-08-03.md`](docs/ux-review-2026-08-03.md),
+  all remain, and the globe still tilts under two fingers. Every small
+  explanatory string now clears WCAG AA in both themes and over both basemaps,
+  worst case 5.12:1, where the worst case used to be 2.74:1 — that one was
+  broader than the review said, because `--chalk-faint` got *lighter* in light
+  mode and so failed in the dark theme too. Still open: the search-result
+  tooltip, the knowledge-rail landmarks of item 6, and the rest. See [`docs/ux-review-2026-08-03.md`](docs/ux-review-2026-08-03.md),
   which covers this site and its sibling together.
 
 ## Two deliberate departures

--- a/artifact.html
+++ b/artifact.html
@@ -20,7 +20,13 @@
   --shale-3:    #1E3742;
   --chalk:      #DDE7E7;
   --chalk-dim:  #90A5AB;
-  --chalk-faint:#5D7178;
+  /* chalk-faint is the colour of every small string that explains what the axes
+     are: the group labels, the presets, the resolver note, the search note, the
+     empty panel. At 9.5-12px none of them is large text, so none gets the 3:1
+     exemption and all of them need 4.5:1. It used to sit at 3.32:1 here and
+     2.98:1 in light mode - where it got LIGHTER, which is backwards. Both values
+     now clear 4.5:1 against the worst surface they land on, --shale-2. */
+  --chalk-faint:#86959A;
   --cyanotype:  #55A0C6;
   --cyanotype-d:#2C6D91;
   --ochre:      #D08A44;
@@ -58,7 +64,7 @@
     --shale-3:    #D6DFDE;
     --chalk:      #101D23;
     --chalk-dim:  #4E656D;
-    --chalk-faint:#7C9198;
+    --chalk-faint:#58676C;
     --cyanotype:  #2A6D91;
     --cyanotype-d:#1B4E69;
     --ochre:      #A2622A;
@@ -84,7 +90,7 @@
 /* The viewer's explicit toggle must win over the media query in BOTH directions. */
 :root[data-theme="dark"] {
   --abyss:#0A1317; --shale:#101E25; --shale-2:#162A33; --shale-3:#1E3742;
-  --chalk:#DDE7E7; --chalk-dim:#90A5AB; --chalk-faint:#5D7178;
+  --chalk:#DDE7E7; --chalk-dim:#90A5AB; --chalk-faint:#86959A;
   --cyanotype:#55A0C6; --cyanotype-d:#2C6D91; --ochre:#D08A44;
   --rule:rgba(146,180,190,0.16); --rule-soft:rgba(146,180,190,0.08);
   --sheen:rgba(255,255,255,0.04);
@@ -96,7 +102,7 @@
 }
 :root[data-theme="light"] {
   --abyss:#E6EBE9; --shale:#F1F4F2; --shale-2:#E4EAE9; --shale-3:#D6DFDE;
-  --chalk:#101D23; --chalk-dim:#4E656D; --chalk-faint:#7C9198;
+  --chalk:#101D23; --chalk-dim:#4E656D; --chalk-faint:#58676C;
   --cyanotype:#2A6D91; --cyanotype-d:#1B4E69; --ochre:#A2622A;
   --rule:rgba(20,50,62,0.20); --rule-soft:rgba(20,50,62,0.09);
   --sheen:rgba(10,30,40,0.03);
@@ -333,13 +339,22 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
    that leaves a keyboard user with no sign of where focus is. Paint it inside. */
 #globe:focus-visible { outline: none; box-shadow: inset 0 0 0 2px var(--cyanotype); }
 #globe.dragging { cursor: grabbing; }
+/* The stage's own background does not follow the theme: .stage.space is a fixed
+   dark gradient with satellite imagery over it. The text on top did follow the
+   theme, so in light mode a dark token landed on a near-black stage - #epistemic
+   measured 3.25:1 there, and .as-of and the legend 2.74:1 over the chart ground.
+   No single theme-independent colour fixes both, because the backdrop is dark
+   regardless under imagery and theme-following under Chart. The discriminator is
+   the basemap, and .stage.space is already toggled with it. */
+.stage.space { --stage-fg: #C6D4D9; --stage-fg-dim: #A3B5BB; }
+.stage       { --stage-fg: var(--chalk-dim); --stage-fg-dim: var(--chalk-dim); }
 .stage-tl { position: absolute; top: 12px; left: 14px; pointer-events: none; max-width: 60%; }
 .as-of {
   font-family: var(--font-display); text-transform: uppercase; letter-spacing: .14em;
-  font-size: 10px; color: var(--chalk-faint);
+  font-size: 10px; color: var(--stage-fg-dim);
 }
 .as-of b { color: var(--cyanotype); font-family: var(--font-data); letter-spacing: 0; font-size: 12px; }
-.epistemic { margin: 4px 0 0; font-size: 12px; color: var(--chalk-dim); line-height: 1.5;
+.epistemic { margin: 4px 0 0; font-size: 12px; color: var(--stage-fg); line-height: 1.5;
   max-width: 52ch; text-wrap: balance; }
 .stage-tr { position: absolute; top: 10px; right: 12px; display: flex; gap: 6px; }
 .iconbtn {
@@ -352,7 +367,7 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 .iconbtn[aria-pressed="true"] { background: var(--shale-3); color: var(--cyanotype); border-color: var(--cyanotype-d); }
 .stage-bl { position: absolute; left: 14px; bottom: 12px; pointer-events: none; }
 .legend { display: flex; flex-direction: column; gap: 3px; }
-.legend div { display: flex; align-items: center; gap: 6px; font-size: 10px; color: var(--chalk-faint); }
+.legend div { display: flex; align-items: center; gap: 6px; font-size: 10px; color: var(--stage-fg-dim); }
 .legend .g { width: 22px; height: 9px; flex: none; }
 
 .tip {

--- a/earth-x-time.html
+++ b/earth-x-time.html
@@ -25,7 +25,13 @@
   --shale-3:    #1E3742;
   --chalk:      #DDE7E7;
   --chalk-dim:  #90A5AB;
-  --chalk-faint:#5D7178;
+  /* chalk-faint is the colour of every small string that explains what the axes
+     are: the group labels, the presets, the resolver note, the search note, the
+     empty panel. At 9.5-12px none of them is large text, so none gets the 3:1
+     exemption and all of them need 4.5:1. It used to sit at 3.32:1 here and
+     2.98:1 in light mode - where it got LIGHTER, which is backwards. Both values
+     now clear 4.5:1 against the worst surface they land on, --shale-2. */
+  --chalk-faint:#86959A;
   --cyanotype:  #55A0C6;
   --cyanotype-d:#2C6D91;
   --ochre:      #D08A44;
@@ -63,7 +69,7 @@
     --shale-3:    #D6DFDE;
     --chalk:      #101D23;
     --chalk-dim:  #4E656D;
-    --chalk-faint:#7C9198;
+    --chalk-faint:#58676C;
     --cyanotype:  #2A6D91;
     --cyanotype-d:#1B4E69;
     --ochre:      #A2622A;
@@ -89,7 +95,7 @@
 /* The viewer's explicit toggle must win over the media query in BOTH directions. */
 :root[data-theme="dark"] {
   --abyss:#0A1317; --shale:#101E25; --shale-2:#162A33; --shale-3:#1E3742;
-  --chalk:#DDE7E7; --chalk-dim:#90A5AB; --chalk-faint:#5D7178;
+  --chalk:#DDE7E7; --chalk-dim:#90A5AB; --chalk-faint:#86959A;
   --cyanotype:#55A0C6; --cyanotype-d:#2C6D91; --ochre:#D08A44;
   --rule:rgba(146,180,190,0.16); --rule-soft:rgba(146,180,190,0.08);
   --sheen:rgba(255,255,255,0.04);
@@ -101,7 +107,7 @@
 }
 :root[data-theme="light"] {
   --abyss:#E6EBE9; --shale:#F1F4F2; --shale-2:#E4EAE9; --shale-3:#D6DFDE;
-  --chalk:#101D23; --chalk-dim:#4E656D; --chalk-faint:#7C9198;
+  --chalk:#101D23; --chalk-dim:#4E656D; --chalk-faint:#58676C;
   --cyanotype:#2A6D91; --cyanotype-d:#1B4E69; --ochre:#A2622A;
   --rule:rgba(20,50,62,0.20); --rule-soft:rgba(20,50,62,0.09);
   --sheen:rgba(10,30,40,0.03);
@@ -338,13 +344,22 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
    that leaves a keyboard user with no sign of where focus is. Paint it inside. */
 #globe:focus-visible { outline: none; box-shadow: inset 0 0 0 2px var(--cyanotype); }
 #globe.dragging { cursor: grabbing; }
+/* The stage's own background does not follow the theme: .stage.space is a fixed
+   dark gradient with satellite imagery over it. The text on top did follow the
+   theme, so in light mode a dark token landed on a near-black stage - #epistemic
+   measured 3.25:1 there, and .as-of and the legend 2.74:1 over the chart ground.
+   No single theme-independent colour fixes both, because the backdrop is dark
+   regardless under imagery and theme-following under Chart. The discriminator is
+   the basemap, and .stage.space is already toggled with it. */
+.stage.space { --stage-fg: #C6D4D9; --stage-fg-dim: #A3B5BB; }
+.stage       { --stage-fg: var(--chalk-dim); --stage-fg-dim: var(--chalk-dim); }
 .stage-tl { position: absolute; top: 12px; left: 14px; pointer-events: none; max-width: 60%; }
 .as-of {
   font-family: var(--font-display); text-transform: uppercase; letter-spacing: .14em;
-  font-size: 10px; color: var(--chalk-faint);
+  font-size: 10px; color: var(--stage-fg-dim);
 }
 .as-of b { color: var(--cyanotype); font-family: var(--font-data); letter-spacing: 0; font-size: 12px; }
-.epistemic { margin: 4px 0 0; font-size: 12px; color: var(--chalk-dim); line-height: 1.5;
+.epistemic { margin: 4px 0 0; font-size: 12px; color: var(--stage-fg); line-height: 1.5;
   max-width: 52ch; text-wrap: balance; }
 .stage-tr { position: absolute; top: 10px; right: 12px; display: flex; gap: 6px; }
 .iconbtn {
@@ -357,7 +372,7 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 .iconbtn[aria-pressed="true"] { background: var(--shale-3); color: var(--cyanotype); border-color: var(--cyanotype-d); }
 .stage-bl { position: absolute; left: 14px; bottom: 12px; pointer-events: none; }
 .legend { display: flex; flex-direction: column; gap: 3px; }
-.legend div { display: flex; align-items: center; gap: 6px; font-size: 10px; color: var(--chalk-faint); }
+.legend div { display: flex; align-items: center; gap: 6px; font-size: 10px; color: var(--stage-fg-dim); }
 .legend .g { width: 22px; height: 9px; flex: none; }
 
 .tip {

--- a/index.html
+++ b/index.html
@@ -25,7 +25,13 @@
   --shale-3:    #1E3742;
   --chalk:      #DDE7E7;
   --chalk-dim:  #90A5AB;
-  --chalk-faint:#5D7178;
+  /* chalk-faint is the colour of every small string that explains what the axes
+     are: the group labels, the presets, the resolver note, the search note, the
+     empty panel. At 9.5-12px none of them is large text, so none gets the 3:1
+     exemption and all of them need 4.5:1. It used to sit at 3.32:1 here and
+     2.98:1 in light mode - where it got LIGHTER, which is backwards. Both values
+     now clear 4.5:1 against the worst surface they land on, --shale-2. */
+  --chalk-faint:#86959A;
   --cyanotype:  #55A0C6;
   --cyanotype-d:#2C6D91;
   --ochre:      #D08A44;
@@ -63,7 +69,7 @@
     --shale-3:    #D6DFDE;
     --chalk:      #101D23;
     --chalk-dim:  #4E656D;
-    --chalk-faint:#7C9198;
+    --chalk-faint:#58676C;
     --cyanotype:  #2A6D91;
     --cyanotype-d:#1B4E69;
     --ochre:      #A2622A;
@@ -89,7 +95,7 @@
 /* The viewer's explicit toggle must win over the media query in BOTH directions. */
 :root[data-theme="dark"] {
   --abyss:#0A1317; --shale:#101E25; --shale-2:#162A33; --shale-3:#1E3742;
-  --chalk:#DDE7E7; --chalk-dim:#90A5AB; --chalk-faint:#5D7178;
+  --chalk:#DDE7E7; --chalk-dim:#90A5AB; --chalk-faint:#86959A;
   --cyanotype:#55A0C6; --cyanotype-d:#2C6D91; --ochre:#D08A44;
   --rule:rgba(146,180,190,0.16); --rule-soft:rgba(146,180,190,0.08);
   --sheen:rgba(255,255,255,0.04);
@@ -101,7 +107,7 @@
 }
 :root[data-theme="light"] {
   --abyss:#E6EBE9; --shale:#F1F4F2; --shale-2:#E4EAE9; --shale-3:#D6DFDE;
-  --chalk:#101D23; --chalk-dim:#4E656D; --chalk-faint:#7C9198;
+  --chalk:#101D23; --chalk-dim:#4E656D; --chalk-faint:#58676C;
   --cyanotype:#2A6D91; --cyanotype-d:#1B4E69; --ochre:#A2622A;
   --rule:rgba(20,50,62,0.20); --rule-soft:rgba(20,50,62,0.09);
   --sheen:rgba(10,30,40,0.03);
@@ -338,13 +344,22 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
    that leaves a keyboard user with no sign of where focus is. Paint it inside. */
 #globe:focus-visible { outline: none; box-shadow: inset 0 0 0 2px var(--cyanotype); }
 #globe.dragging { cursor: grabbing; }
+/* The stage's own background does not follow the theme: .stage.space is a fixed
+   dark gradient with satellite imagery over it. The text on top did follow the
+   theme, so in light mode a dark token landed on a near-black stage - #epistemic
+   measured 3.25:1 there, and .as-of and the legend 2.74:1 over the chart ground.
+   No single theme-independent colour fixes both, because the backdrop is dark
+   regardless under imagery and theme-following under Chart. The discriminator is
+   the basemap, and .stage.space is already toggled with it. */
+.stage.space { --stage-fg: #C6D4D9; --stage-fg-dim: #A3B5BB; }
+.stage       { --stage-fg: var(--chalk-dim); --stage-fg-dim: var(--chalk-dim); }
 .stage-tl { position: absolute; top: 12px; left: 14px; pointer-events: none; max-width: 60%; }
 .as-of {
   font-family: var(--font-display); text-transform: uppercase; letter-spacing: .14em;
-  font-size: 10px; color: var(--chalk-faint);
+  font-size: 10px; color: var(--stage-fg-dim);
 }
 .as-of b { color: var(--cyanotype); font-family: var(--font-data); letter-spacing: 0; font-size: 12px; }
-.epistemic { margin: 4px 0 0; font-size: 12px; color: var(--chalk-dim); line-height: 1.5;
+.epistemic { margin: 4px 0 0; font-size: 12px; color: var(--stage-fg); line-height: 1.5;
   max-width: 52ch; text-wrap: balance; }
 .stage-tr { position: absolute; top: 10px; right: 12px; display: flex; gap: 6px; }
 .iconbtn {
@@ -357,7 +372,7 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 .iconbtn[aria-pressed="true"] { background: var(--shale-3); color: var(--cyanotype); border-color: var(--cyanotype-d); }
 .stage-bl { position: absolute; left: 14px; bottom: 12px; pointer-events: none; }
 .legend { display: flex; flex-direction: column; gap: 3px; }
-.legend div { display: flex; align-items: center; gap: 6px; font-size: 10px; color: var(--chalk-faint); }
+.legend div { display: flex; align-items: center; gap: 6px; font-size: 10px; color: var(--stage-fg-dim); }
 .legend .g { width: 22px; height: 9px; flex: none; }
 
 .tip {

--- a/src/00_head.html
+++ b/src/00_head.html
@@ -18,7 +18,13 @@
   --shale-3:    #1E3742;
   --chalk:      #DDE7E7;
   --chalk-dim:  #90A5AB;
-  --chalk-faint:#5D7178;
+  /* chalk-faint is the colour of every small string that explains what the axes
+     are: the group labels, the presets, the resolver note, the search note, the
+     empty panel. At 9.5-12px none of them is large text, so none gets the 3:1
+     exemption and all of them need 4.5:1. It used to sit at 3.32:1 here and
+     2.98:1 in light mode - where it got LIGHTER, which is backwards. Both values
+     now clear 4.5:1 against the worst surface they land on, --shale-2. */
+  --chalk-faint:#86959A;
   --cyanotype:  #55A0C6;
   --cyanotype-d:#2C6D91;
   --ochre:      #D08A44;
@@ -56,7 +62,7 @@
     --shale-3:    #D6DFDE;
     --chalk:      #101D23;
     --chalk-dim:  #4E656D;
-    --chalk-faint:#7C9198;
+    --chalk-faint:#58676C;
     --cyanotype:  #2A6D91;
     --cyanotype-d:#1B4E69;
     --ochre:      #A2622A;
@@ -82,7 +88,7 @@
 /* The viewer's explicit toggle must win over the media query in BOTH directions. */
 :root[data-theme="dark"] {
   --abyss:#0A1317; --shale:#101E25; --shale-2:#162A33; --shale-3:#1E3742;
-  --chalk:#DDE7E7; --chalk-dim:#90A5AB; --chalk-faint:#5D7178;
+  --chalk:#DDE7E7; --chalk-dim:#90A5AB; --chalk-faint:#86959A;
   --cyanotype:#55A0C6; --cyanotype-d:#2C6D91; --ochre:#D08A44;
   --rule:rgba(146,180,190,0.16); --rule-soft:rgba(146,180,190,0.08);
   --sheen:rgba(255,255,255,0.04);
@@ -94,7 +100,7 @@
 }
 :root[data-theme="light"] {
   --abyss:#E6EBE9; --shale:#F1F4F2; --shale-2:#E4EAE9; --shale-3:#D6DFDE;
-  --chalk:#101D23; --chalk-dim:#4E656D; --chalk-faint:#7C9198;
+  --chalk:#101D23; --chalk-dim:#4E656D; --chalk-faint:#58676C;
   --cyanotype:#2A6D91; --cyanotype-d:#1B4E69; --ochre:#A2622A;
   --rule:rgba(20,50,62,0.20); --rule-soft:rgba(20,50,62,0.09);
   --sheen:rgba(10,30,40,0.03);
@@ -331,13 +337,22 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
    that leaves a keyboard user with no sign of where focus is. Paint it inside. */
 #globe:focus-visible { outline: none; box-shadow: inset 0 0 0 2px var(--cyanotype); }
 #globe.dragging { cursor: grabbing; }
+/* The stage's own background does not follow the theme: .stage.space is a fixed
+   dark gradient with satellite imagery over it. The text on top did follow the
+   theme, so in light mode a dark token landed on a near-black stage - #epistemic
+   measured 3.25:1 there, and .as-of and the legend 2.74:1 over the chart ground.
+   No single theme-independent colour fixes both, because the backdrop is dark
+   regardless under imagery and theme-following under Chart. The discriminator is
+   the basemap, and .stage.space is already toggled with it. */
+.stage.space { --stage-fg: #C6D4D9; --stage-fg-dim: #A3B5BB; }
+.stage       { --stage-fg: var(--chalk-dim); --stage-fg-dim: var(--chalk-dim); }
 .stage-tl { position: absolute; top: 12px; left: 14px; pointer-events: none; max-width: 60%; }
 .as-of {
   font-family: var(--font-display); text-transform: uppercase; letter-spacing: .14em;
-  font-size: 10px; color: var(--chalk-faint);
+  font-size: 10px; color: var(--stage-fg-dim);
 }
 .as-of b { color: var(--cyanotype); font-family: var(--font-data); letter-spacing: 0; font-size: 12px; }
-.epistemic { margin: 4px 0 0; font-size: 12px; color: var(--chalk-dim); line-height: 1.5;
+.epistemic { margin: 4px 0 0; font-size: 12px; color: var(--stage-fg); line-height: 1.5;
   max-width: 52ch; text-wrap: balance; }
 .stage-tr { position: absolute; top: 10px; right: 12px; display: flex; gap: 6px; }
 .iconbtn {
@@ -350,7 +365,7 @@ button { background: none; border: none; cursor: pointer; padding: 0; }
 .iconbtn[aria-pressed="true"] { background: var(--shale-3); color: var(--cyanotype); border-color: var(--cyanotype-d); }
 .stage-bl { position: absolute; left: 14px; bottom: 12px; pointer-events: none; }
 .legend { display: flex; flex-direction: column; gap: 3px; }
-.legend div { display: flex; align-items: center; gap: 6px; font-size: 10px; color: var(--chalk-faint); }
+.legend div { display: flex; align-items: center; gap: 6px; font-size: 10px; color: var(--stage-fg-dim); }
 .legend .g { width: 22px; height: 9px; flex: none; }
 
 .tip {

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -27,7 +27,7 @@ hypothetical.
 Requires playwright with chromium (`pip install playwright && playwright install
 chromium`). Exits non-zero on any failure, so it can gate a build.
 """
-import argparse, functools, http.server, json, os, socketserver, sys, threading
+import argparse, base64, functools, http.server, json, os, re, socketserver, sys, threading
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)
@@ -779,6 +779,145 @@ def run_mobile(url, headed, report):
         browser.close()
 
 
+# Relative luminance and contrast ratio, WCAG 2.x.
+def _lum(rgb):
+    out = []
+    for v in rgb:
+        v = v / 255.0
+        out.append(v / 12.92 if v <= 0.03928 else ((v + 0.055) / 1.055) ** 2.4)
+    return 0.2126 * out[0] + 0.7152 * out[1] + 0.0722 * out[2]
+
+
+def _ratio(a, b):
+    l1, l2 = _lum(a), _lum(b)
+    return (max(l1, l2) + 0.05) / (min(l1, l2) + 0.05)
+
+
+def _rgb(css):
+    m = re.match(r"rgba?\(([^)]+)\)", css or "")
+    if not m:
+        return None
+    parts = [float(x) for x in re.split(r"[,\s/]+", m.group(1).strip()) if x]
+    return parts[:3]
+
+
+# Everything here is 9.5-12px, so none of it is "large text" and none of it gets
+# the 3:1 exemption. These are the strings that say what the axes are.
+SMALL_TEXT = ["#subhint", ".instrument .lbl", "#presets button", "#resnote",
+              "#search-note", ".detail .empty", ".chron-bar .rd", ".iconbtn"]
+# The stage is the awkward one: .stage.space is a fixed dark gradient with
+# imagery over it, so its backdrop does not follow the theme while its text did.
+# A computed backgroundColor cannot see a gradient, so these are measured by
+# photographing the overlay's own box with the overlays hidden.
+STAGE_TEXT = ["#epistemic", ".as-of", ".stage-bl .legend div"]
+AA = 4.5
+
+COMPUTED_CONTRAST = """(sels) => {
+  const parse = str => { const m = String(str).match(/rgba?\\(([^)]+)\\)/); if (!m) return null;
+    const p = m[1].split(/[,\\s\\/]+/).filter(Boolean).map(Number);
+    return { rgb: p.slice(0, 3), a: p.length > 3 ? p[3] : 1 }; };
+  const out = [];
+  for (const s of sels) {
+    const el = document.querySelector(s);
+    if (!el) { out.push({ s, missing: true }); continue; }
+    const cs = getComputedStyle(el);
+    const fg = parse(cs.color); if (!fg) continue;
+    const chain = []; for (let n = el.parentElement; n; n = n.parentElement) chain.push(n);
+    chain.reverse();
+    let bg = [255, 255, 255];
+    for (const n of chain) {
+      const c = parse(getComputedStyle(n).backgroundColor);
+      if (!c || c.a === 0) continue;
+      bg = [0, 1, 2].map(i => c.rgb[i] * c.a + bg[i] * (1 - c.a));
+    }
+    const f = [0, 1, 2].map(i => fg.rgb[i] * fg.a + bg[i] * (1 - fg.a));
+    out.push({ s, fg: f, bg, size: cs.fontSize });
+  }
+  return out;
+}"""
+
+
+def _backdrop(page, sel):
+    """The pixels actually painted behind an overlay, with the overlays hidden."""
+    box = page.evaluate("""(s) => {
+      const el = document.querySelector(s); if (!el) return null;
+      const r = el.getBoundingClientRect();
+      if (r.width < 4 || r.height < 4) return null;
+      return { color: getComputedStyle(el).color, size: getComputedStyle(el).fontSize,
+               x: Math.round(r.left), y: Math.round(r.top),
+               w: Math.round(r.width), h: Math.round(r.height) };
+    }""", sel)
+    if not box:
+        return None
+    page.evaluate("() => { for (const n of document.querySelectorAll('.stage-tl, .stage-bl'))"
+                  " n.style.visibility = 'hidden'; }")
+    page.wait_for_timeout(180)
+    shot = page.screenshot(clip={"x": box["x"], "y": box["y"],
+                                 "width": box["w"], "height": box["h"]})
+    page.evaluate("() => { for (const n of document.querySelectorAll('.stage-tl, .stage-bl'))"
+                  " n.style.visibility = ''; }")
+    page.wait_for_timeout(120)
+    mean = page.evaluate("""async (b64) => {
+      const img = new Image();
+      await new Promise(r => { img.onload = r; img.src = 'data:image/png;base64,' + b64; });
+      const c = document.createElement('canvas'); c.width = img.width; c.height = img.height;
+      const g = c.getContext('2d'); g.drawImage(img, 0, 0);
+      const d = g.getImageData(0, 0, c.width, c.height).data;
+      let r = 0, gg = 0, bb = 0, n = 0;
+      for (let i = 0; i < d.length; i += 4) { r += d[i]; gg += d[i+1]; bb += d[i+2]; n++; }
+      return [r / n, gg / n, bb / n];
+    }""", base64.b64encode(shot).decode())
+    return box, mean
+
+
+def run_contrast(url, headed, report):
+    """Both themes, both basemaps, measured rather than eyeballed.
+
+    --chalk-faint used to sit at 3.32:1 in dark and 2.98:1 in light - where it
+    got LIGHTER, which is backwards - and the stage overlays measured 3.25:1 in
+    light over imagery, because .stage.space is a fixed dark gradient and only
+    the text followed the theme.
+    """
+    from playwright.sync_api import sync_playwright
+
+    print("\n  -- contrast, both themes --", flush=True)
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=not headed)
+        for scheme in ("dark", "light"):
+            ctx = browser.new_context(viewport={"width": 1440, "height": 900},
+                                      device_scale_factor=1, color_scheme=scheme)
+            page = ctx.new_page()
+            page.goto(url, wait_until="load", timeout=45000)
+            page.wait_for_timeout(1500)
+            page.evaluate("S.selection = null; changed(); renderNow();")
+            page.wait_for_timeout(250)
+
+            worst = []
+            for row in page.evaluate(COMPUTED_CONTRAST, SMALL_TEXT):
+                if row.get("missing"):
+                    worst.append((0.0, row["s"] + " (missing)"))
+                    continue
+                worst.append((_ratio(row["fg"], row["bg"]), f"{row['s']} @{row['size']}"))
+            for basemap in ("satellite", "chart"):
+                if basemap == "chart":
+                    page.click("#btn-basemap")
+                    page.wait_for_timeout(700)
+                for sel in STAGE_TEXT:
+                    got = _backdrop(page, sel)
+                    if not got:
+                        continue
+                    box, bg = got
+                    fg = _rgb(box["color"])
+                    worst.append((_ratio(fg, bg), f"{sel} @{box['size']} over {basemap}"))
+
+            worst.sort()
+            lo, who = worst[0]
+            report.check(f"every small string clears AA in {scheme} mode",
+                         lo >= AA, f"worst {lo:.2f}:1  {who}")
+            ctx.close()
+        browser.close()
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--url", default=None, help="test a deployed URL instead of the local build")
@@ -800,6 +939,7 @@ def main():
     try:
         run(url, a.headed, report)
         run_mobile(url, a.headed, report)
+        run_contrast(url, a.headed, report)
     finally:
         if httpd:
             httpd.shutdown()


### PR DESCRIPTION
Wave 6 of the bug audit. Closes #19. Implements item 3 of `docs/ux-review-2026-08-03.md` — and it is broader than the review states: the review reads as a light-mode problem, but **dark mode fails too**.

At 9.5–12px nothing on this page is large text, so nothing gets the 3:1 exemption and everything needs 4.5:1.

## Cause 1 — `--chalk-faint` gets lighter in light mode

```css
:root                                { --chalk-dim: #90A5AB; --chalk-faint: #5D7178; }
@media (prefers-color-scheme: light) { --chalk-dim: #4E656D; --chalk-faint: #7C9198; }
```

`--chalk-dim` flips correctly. `--chalk-faint` goes **lighter** (#5D7178 → #7C9198), which is backwards — and it is the colour of every string that explains what the page is: the group labels, the presets, the resolver note, the search note, the subject hint, the empty panel.

| element | size | dark | light |
|---|---|---|---|
| `.instrument .lbl` | 10px 600 | 3.32:1 | 2.98:1 |
| `#presets button` | 9.5px | 3.32:1 | 2.98:1 |
| `#resnote`, `#search-note`, `#subhint` | 10.5px | 3.32:1 | 2.98:1 |
| `.detail .empty` | 12px | 3.32:1 | 2.98:1 |

Both values now clear 4.5:1 against the worst surface they land on, `--shale-2`.

## Cause 2 — the stage's background does not follow the theme, but its text did

`.stage.space` is a fixed dark radial gradient with satellite imagery over it. Measured by photographing each overlay's own box with the overlays hidden — a computed `background-color` cannot see a gradient, which is exactly why a naive harness reports these as passing:

| theme / basemap | element | ratio |
|---|---|---|
| light / satellite | `#epistemic` | **3.25:1** |
| light / chart | `.as-of`, legend | **2.74:1** |
| dark / satellite | `.as-of`, legend | **3.93:1** |
| dark / chart | `.as-of`, legend | **3.66:1** |

The 3.25:1 matches the review's figure exactly.

No single theme-independent colour fixes this: the backdrop is dark regardless under imagery and theme-following under Chart. The discriminator is the basemap, not the theme — and `.stage.space` is already toggled with it. So the overlays take a pinned light-on-dark pair there and `--chalk-dim` otherwise.

After:

```
dark  / satellite   13.21 / 9.48 / 9.52
dark  / chart        7.29 / 7.29 / 7.29
light / satellite   13.21 / 9.48 / 9.52
light / chart        5.12 / 5.12 / 5.12
```

Worst case across all four combinations: 5.12:1.

## Verification

Two new checks, one per theme, each naming its worst offender:

```
[PASS] every small string clears AA in dark mode    worst 5.49:1  #presets button @9.5px
[PASS] every small string clears AA in light mode   worst 5.12:1  #epistemic @12px over chart
```

With the old palette restored:

```
[FAIL] every small string clears AA in dark mode    worst 3.32:1  #presets button @9.5px
[FAIL] every small string clears AA in light mode   worst 2.74:1  .as-of @10px over chart
67/69 checks passed
```

All three gates clean on the branch:

```
python3 tools/validate_graph.py                 ERRORS (0)
python3 tools/check_no_local_paths.py --all     clean
python3 tools/build.py                          69/69 checks passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_