### PR TITLE
Count what is drawn, and sweep the rail the rail actually has

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,10 @@ Then it loads the page once more in each theme and measures the contrast of
 every small explanatory string against its real background — photographing the
 painted pixels behind the stage overlays, because a computed `background-color`
 cannot see the gradient they sit on. And it asks the page where the knowledge
-rail ends, and compares that with what the Python tools read. 70 checks, wired
-into `build.py`, exits non-zero.
+rail ends, and compares that with what the Python tools read, whether every
+subject chip counts exactly the marks it accounts for, and whether Replay
+sweeps the rail the page actually has. 73 checks, wired into `build.py`, exits
+non-zero.
 
 It exists because this project lost an entire build to a boot failure that
 nothing detected: a legend swatch read the wrong palette key, `undefined` reached

--- a/artifact.html
+++ b/artifact.html
@@ -1049,8 +1049,6 @@ function queryFacts(A) {
     const subjectOn = res.subjects.some(s => A.subjects.has(s));
     const zoomOK = z >= res.zoomMin - 0.001 || res.significance >= 5 || A.selection === id;
 
-    for (const s of res.subjects) if (s in subjectCounts) subjectCounts[s]++;
-
     items[id] = {
       id, ref: R.referents[id], res,
       inWindow: overlaps,
@@ -1137,6 +1135,20 @@ function queryFacts(A) {
   }
 
   const visible = order.map(i => items[i]).filter(i => i.visible);
+
+  /* The chip counts come off `visible` itself, and nothing else. They used to be
+     tallied at the top of this function, before the window, the zoom band and
+     the roll-up had been applied to anything, so they moved with knowledge-time
+     and nothing else: zoomed to the Holocene the astronomy chip still read 11
+     with no astronomy on screen at all. Counting a set the renderers do not draw
+     is the second filtering path this function exists to avoid - so the number
+     on a chip is now, by construction, the number of marks it accounts for.
+     A switched-off subject reads 0, which is what the screen shows; the chip is
+     already drawn as off, so the state is not carried by the number. */
+  for (const it of visible) {
+    for (const s of it.res.subjects) if (s in subjectCounts) subjectCounts[s]++;
+  }
+
   const liveEdges = edges.filter(e =>
     e.from.visible && e.to.visible &&
     (!A.focus || e.from.inFocus || e.to.inFocus));
@@ -2188,8 +2200,11 @@ function drawKrail() {
   kx.beginPath(); kx.moveTo(spine + 0.5, KPAD); kx.lineTo(spine + 0.5, KH - KPAD); kx.stroke();
 
   // ticks
+  // The first round fifty at or after KT_MIN. Starting at a literal 1650 drew
+  // every tick below the floor outside the canvas - ktToY(1650) is 827px in a
+  // 737px rail once KT_MIN moves up.
   kx.font = '400 9px xt-mono, monospace';
-  for (let yr = 1650; yr <= KT_MAX; yr += 50) {
+  for (let yr = Math.ceil(KT_MIN / 50) * 50; yr <= KT_MAX; yr += 50) {
     const py = ktToY(yr);
     kx.strokeStyle = withAlpha(CSSV['chalk-faint'], 0.45);
     kx.beginPath(); kx.moveTo(spine + 0.5, py); kx.lineTo(spine + 5, py); kx.stroke();
@@ -2206,17 +2221,24 @@ function drawKrail() {
 }
 
 /* ----------------------------------------------------------------- replay */
+/* Sixteen seconds from one end of the rail to the other. The span used to be
+   measured from a literal 1650 rather than from KT_MIN, so with the floor
+   anywhere above that the first seconds of a replay produced values setKt
+   clamped away - the rail sat still - and the rest ran at a rate computed for a
+   longer rail than the one on screen. startReplay looked right only because
+   setKt clamped for it, which is a second mechanism covering for this one. */
 let playT = 0;
+const REPLAY_SECONDS = 16;
 function tickReplay(dt) {
   if (!S.playing) return;
   playT += dt;
-  const span = KT_MAX - 1650;
-  const next = Math.round(1650 + (playT / 16) * span);
+  const span = KT_MAX - KT_MIN;
+  const next = Math.round(KT_MIN + (playT / REPLAY_SECONDS) * span);
   if (next >= KT_MAX) { setKt(KT_MAX); stopReplay(); return; }
   setKt(next);
 }
 function startReplay() {
-  S.playing = true; playT = 0; setKt(1650);
+  S.playing = true; playT = 0; setKt(KT_MIN);
   document.getElementById('btn-play').setAttribute('aria-pressed', 'true');
   document.getElementById('btn-play').textContent = 'Stop';
 }

--- a/earth-x-time.html
+++ b/earth-x-time.html
@@ -1056,8 +1056,6 @@ function queryFacts(A) {
     const subjectOn = res.subjects.some(s => A.subjects.has(s));
     const zoomOK = z >= res.zoomMin - 0.001 || res.significance >= 5 || A.selection === id;
 
-    for (const s of res.subjects) if (s in subjectCounts) subjectCounts[s]++;
-
     items[id] = {
       id, ref: R.referents[id], res,
       inWindow: overlaps,
@@ -1144,6 +1142,20 @@ function queryFacts(A) {
   }
 
   const visible = order.map(i => items[i]).filter(i => i.visible);
+
+  /* The chip counts come off `visible` itself, and nothing else. They used to be
+     tallied at the top of this function, before the window, the zoom band and
+     the roll-up had been applied to anything, so they moved with knowledge-time
+     and nothing else: zoomed to the Holocene the astronomy chip still read 11
+     with no astronomy on screen at all. Counting a set the renderers do not draw
+     is the second filtering path this function exists to avoid - so the number
+     on a chip is now, by construction, the number of marks it accounts for.
+     A switched-off subject reads 0, which is what the screen shows; the chip is
+     already drawn as off, so the state is not carried by the number. */
+  for (const it of visible) {
+    for (const s of it.res.subjects) if (s in subjectCounts) subjectCounts[s]++;
+  }
+
   const liveEdges = edges.filter(e =>
     e.from.visible && e.to.visible &&
     (!A.focus || e.from.inFocus || e.to.inFocus));
@@ -2195,8 +2207,11 @@ function drawKrail() {
   kx.beginPath(); kx.moveTo(spine + 0.5, KPAD); kx.lineTo(spine + 0.5, KH - KPAD); kx.stroke();
 
   // ticks
+  // The first round fifty at or after KT_MIN. Starting at a literal 1650 drew
+  // every tick below the floor outside the canvas - ktToY(1650) is 827px in a
+  // 737px rail once KT_MIN moves up.
   kx.font = '400 9px xt-mono, monospace';
-  for (let yr = 1650; yr <= KT_MAX; yr += 50) {
+  for (let yr = Math.ceil(KT_MIN / 50) * 50; yr <= KT_MAX; yr += 50) {
     const py = ktToY(yr);
     kx.strokeStyle = withAlpha(CSSV['chalk-faint'], 0.45);
     kx.beginPath(); kx.moveTo(spine + 0.5, py); kx.lineTo(spine + 5, py); kx.stroke();
@@ -2213,17 +2228,24 @@ function drawKrail() {
 }
 
 /* ----------------------------------------------------------------- replay */
+/* Sixteen seconds from one end of the rail to the other. The span used to be
+   measured from a literal 1650 rather than from KT_MIN, so with the floor
+   anywhere above that the first seconds of a replay produced values setKt
+   clamped away - the rail sat still - and the rest ran at a rate computed for a
+   longer rail than the one on screen. startReplay looked right only because
+   setKt clamped for it, which is a second mechanism covering for this one. */
 let playT = 0;
+const REPLAY_SECONDS = 16;
 function tickReplay(dt) {
   if (!S.playing) return;
   playT += dt;
-  const span = KT_MAX - 1650;
-  const next = Math.round(1650 + (playT / 16) * span);
+  const span = KT_MAX - KT_MIN;
+  const next = Math.round(KT_MIN + (playT / REPLAY_SECONDS) * span);
   if (next >= KT_MAX) { setKt(KT_MAX); stopReplay(); return; }
   setKt(next);
 }
 function startReplay() {
-  S.playing = true; playT = 0; setKt(1650);
+  S.playing = true; playT = 0; setKt(KT_MIN);
   document.getElementById('btn-play').setAttribute('aria-pressed', 'true');
   document.getElementById('btn-play').textContent = 'Stop';
 }

--- a/index.html
+++ b/index.html
@@ -1056,8 +1056,6 @@ function queryFacts(A) {
     const subjectOn = res.subjects.some(s => A.subjects.has(s));
     const zoomOK = z >= res.zoomMin - 0.001 || res.significance >= 5 || A.selection === id;
 
-    for (const s of res.subjects) if (s in subjectCounts) subjectCounts[s]++;
-
     items[id] = {
       id, ref: R.referents[id], res,
       inWindow: overlaps,
@@ -1144,6 +1142,20 @@ function queryFacts(A) {
   }
 
   const visible = order.map(i => items[i]).filter(i => i.visible);
+
+  /* The chip counts come off `visible` itself, and nothing else. They used to be
+     tallied at the top of this function, before the window, the zoom band and
+     the roll-up had been applied to anything, so they moved with knowledge-time
+     and nothing else: zoomed to the Holocene the astronomy chip still read 11
+     with no astronomy on screen at all. Counting a set the renderers do not draw
+     is the second filtering path this function exists to avoid - so the number
+     on a chip is now, by construction, the number of marks it accounts for.
+     A switched-off subject reads 0, which is what the screen shows; the chip is
+     already drawn as off, so the state is not carried by the number. */
+  for (const it of visible) {
+    for (const s of it.res.subjects) if (s in subjectCounts) subjectCounts[s]++;
+  }
+
   const liveEdges = edges.filter(e =>
     e.from.visible && e.to.visible &&
     (!A.focus || e.from.inFocus || e.to.inFocus));
@@ -2195,8 +2207,11 @@ function drawKrail() {
   kx.beginPath(); kx.moveTo(spine + 0.5, KPAD); kx.lineTo(spine + 0.5, KH - KPAD); kx.stroke();
 
   // ticks
+  // The first round fifty at or after KT_MIN. Starting at a literal 1650 drew
+  // every tick below the floor outside the canvas - ktToY(1650) is 827px in a
+  // 737px rail once KT_MIN moves up.
   kx.font = '400 9px xt-mono, monospace';
-  for (let yr = 1650; yr <= KT_MAX; yr += 50) {
+  for (let yr = Math.ceil(KT_MIN / 50) * 50; yr <= KT_MAX; yr += 50) {
     const py = ktToY(yr);
     kx.strokeStyle = withAlpha(CSSV['chalk-faint'], 0.45);
     kx.beginPath(); kx.moveTo(spine + 0.5, py); kx.lineTo(spine + 5, py); kx.stroke();
@@ -2213,17 +2228,24 @@ function drawKrail() {
 }
 
 /* ----------------------------------------------------------------- replay */
+/* Sixteen seconds from one end of the rail to the other. The span used to be
+   measured from a literal 1650 rather than from KT_MIN, so with the floor
+   anywhere above that the first seconds of a replay produced values setKt
+   clamped away - the rail sat still - and the rest ran at a rate computed for a
+   longer rail than the one on screen. startReplay looked right only because
+   setKt clamped for it, which is a second mechanism covering for this one. */
 let playT = 0;
+const REPLAY_SECONDS = 16;
 function tickReplay(dt) {
   if (!S.playing) return;
   playT += dt;
-  const span = KT_MAX - 1650;
-  const next = Math.round(1650 + (playT / 16) * span);
+  const span = KT_MAX - KT_MIN;
+  const next = Math.round(KT_MIN + (playT / REPLAY_SECONDS) * span);
   if (next >= KT_MAX) { setKt(KT_MAX); stopReplay(); return; }
   setKt(next);
 }
 function startReplay() {
-  S.playing = true; playT = 0; setKt(1650);
+  S.playing = true; playT = 0; setKt(KT_MIN);
   document.getElementById('btn-play').setAttribute('aria-pressed', 'true');
   document.getElementById('btn-play').textContent = 'Stop';
 }

--- a/src/30_model.js
+++ b/src/30_model.js
@@ -146,8 +146,6 @@ function queryFacts(A) {
     const subjectOn = res.subjects.some(s => A.subjects.has(s));
     const zoomOK = z >= res.zoomMin - 0.001 || res.significance >= 5 || A.selection === id;
 
-    for (const s of res.subjects) if (s in subjectCounts) subjectCounts[s]++;
-
     items[id] = {
       id, ref: R.referents[id], res,
       inWindow: overlaps,
@@ -234,6 +232,20 @@ function queryFacts(A) {
   }
 
   const visible = order.map(i => items[i]).filter(i => i.visible);
+
+  /* The chip counts come off `visible` itself, and nothing else. They used to be
+     tallied at the top of this function, before the window, the zoom band and
+     the roll-up had been applied to anything, so they moved with knowledge-time
+     and nothing else: zoomed to the Holocene the astronomy chip still read 11
+     with no astronomy on screen at all. Counting a set the renderers do not draw
+     is the second filtering path this function exists to avoid - so the number
+     on a chip is now, by construction, the number of marks it accounts for.
+     A switched-off subject reads 0, which is what the screen shows; the chip is
+     already drawn as off, so the state is not carried by the number. */
+  for (const it of visible) {
+    for (const s of it.res.subjects) if (s in subjectCounts) subjectCounts[s]++;
+  }
+
   const liveEdges = edges.filter(e =>
     e.from.visible && e.to.visible &&
     (!A.focus || e.from.inFocus || e.to.inFocus));

--- a/src/60_krail.js
+++ b/src/60_krail.js
@@ -69,8 +69,11 @@ function drawKrail() {
   kx.beginPath(); kx.moveTo(spine + 0.5, KPAD); kx.lineTo(spine + 0.5, KH - KPAD); kx.stroke();
 
   // ticks
+  // The first round fifty at or after KT_MIN. Starting at a literal 1650 drew
+  // every tick below the floor outside the canvas - ktToY(1650) is 827px in a
+  // 737px rail once KT_MIN moves up.
   kx.font = '400 9px xt-mono, monospace';
-  for (let yr = 1650; yr <= KT_MAX; yr += 50) {
+  for (let yr = Math.ceil(KT_MIN / 50) * 50; yr <= KT_MAX; yr += 50) {
     const py = ktToY(yr);
     kx.strokeStyle = withAlpha(CSSV['chalk-faint'], 0.45);
     kx.beginPath(); kx.moveTo(spine + 0.5, py); kx.lineTo(spine + 5, py); kx.stroke();
@@ -87,17 +90,24 @@ function drawKrail() {
 }
 
 /* ----------------------------------------------------------------- replay */
+/* Sixteen seconds from one end of the rail to the other. The span used to be
+   measured from a literal 1650 rather than from KT_MIN, so with the floor
+   anywhere above that the first seconds of a replay produced values setKt
+   clamped away - the rail sat still - and the rest ran at a rate computed for a
+   longer rail than the one on screen. startReplay looked right only because
+   setKt clamped for it, which is a second mechanism covering for this one. */
 let playT = 0;
+const REPLAY_SECONDS = 16;
 function tickReplay(dt) {
   if (!S.playing) return;
   playT += dt;
-  const span = KT_MAX - 1650;
-  const next = Math.round(1650 + (playT / 16) * span);
+  const span = KT_MAX - KT_MIN;
+  const next = Math.round(KT_MIN + (playT / REPLAY_SECONDS) * span);
   if (next >= KT_MAX) { setKt(KT_MAX); stopReplay(); return; }
   setKt(next);
 }
 function startReplay() {
-  S.playing = true; playT = 0; setKt(1650);
+  S.playing = true; playT = 0; setKt(KT_MIN);
   document.getElementById('btn-play').setAttribute('aria-pressed', 'true');
   document.getElementById('btn-play').textContent = 'Stop';
 }

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -602,6 +602,85 @@ def run(url, headed, report):
                      and rail["nowLabel"] == str(PY_MAX) and rail["diffMax"] == PY_MAX,
                      f"python {PY_MIN}..{PY_MAX}   page {json.dumps(rail)}")
 
+        # ------- 16. the chips count the marks they account for, and only those
+        # subjectCounts was tallied before the window, the zoom band and the
+        # roll-up had been applied, so it moved with knowledge-time and nothing
+        # else: zoomed to the Holocene the astronomy chip still read 11 with no
+        # astronomy drawn anywhere.
+        chips = page.evaluate("""() => {
+          const out = [];
+          const views = [
+            { name: 'all 4.6 Ga',        win: [0, 4.6e9],  kt: KT_MAX },
+            { name: 'last 60,000 years', win: [0, 60000],  kt: KT_MAX },
+            { name: 'since the dinosaurs', win: [0, 7.0e7], kt: KT_MAX },
+            { name: 'knowledge-time 1800', win: [0, 4.6e9], kt: 1800 }
+          ];
+          for (const v of views) {
+            S.subjects = new Set(SUBJECTS); S.focus = null; S.selection = null;
+            setKt(v.kt); setWindow(v.win[0], v.win[1]); renderNow();
+            const F = facts();
+            const drawn = {};
+            for (const s of SUBJECTS) drawn[s] = 0;
+            for (const it of F.visible)
+              for (const s of it.res.subjects) if (s in drawn) drawn[s]++;
+            const chip = {};
+            for (const b of document.querySelectorAll('#subjects .sub'))
+              chip[b.dataset.sub] = +b.querySelector('.cnt').textContent;
+            const bad = SUBJECTS.filter(s => chip[s] !== drawn[s]);
+            if (bad.length) out.push({ view: v.name, bad, chip, drawn });
+          }
+          return out;
+        }""")
+        report.check("every subject chip counts the marks it accounts for",
+                     chips == [], json.dumps(chips)[:240])
+
+        # ---------------- 17. Replay sweeps the rail the page actually has
+        # The span was measured from a literal 1650 rather than KT_MIN, so with
+        # the floor anywhere above that the opening seconds produced values
+        # setKt clamped away - the rail sat still - and the rest ran at a rate
+        # computed for a longer rail than the one on screen.
+        replay = page.evaluate("""() => {
+          startReplay();
+          const start = S.kt;
+          tickReplay(0.5);            // half a second in, it must already move
+          const early = S.kt;
+          for (let i = 0; i < 40; i++) tickReplay(0.5);
+          const end = S.kt;
+          stopReplay(); setKt(KT_MAX);
+          return { start, early, end, min: KT_MIN, max: KT_MAX, playing: S.playing };
+        }""")
+        report.check("Replay sweeps from the floor of the rail to its ceiling",
+                     replay["start"] == replay["min"]
+                     and replay["early"] > replay["start"]
+                     and replay["end"] == replay["max"]
+                     and replay["playing"] is False,
+                     json.dumps(replay))
+
+        # Read back what drawKrail actually paints, rather than recomputing the
+        # loop bounds here - a check that restates the code it is checking
+        # cannot fail. The tick loop started at a literal 1650, so every tick
+        # below the floor was painted outside the canvas: ktToY(1650) is 827px
+        # in a 737px rail once KT_MIN moves up.
+        rail_ticks = page.evaluate("""() => {
+          const ctx = document.getElementById('krailcv').getContext('2d');
+          const real = ctx.fillText.bind(ctx);
+          const seen = [];
+          ctx.fillText = function (t, x, y) { seen.push({ t, y }); return real(t, x, y); };
+          needKrail = true; drawKrail();
+          ctx.fillText = real;
+          const years = seen.filter(s => /^\\d{4}$/.test(s.t));
+          return {
+            KT_MIN, KT_MAX, height: KH, pad: KPAD, count: years.length,
+            outsideRange: years.filter(s => +s.t < KT_MIN || +s.t > KT_MAX).map(s => s.t),
+            outsideCanvas: years.filter(s => s.y < 0 || s.y > KH).map(s => `${s.t}@${Math.round(s.y)}`)
+          };
+        }""")
+        report.check("every rail tick is a year on the rail, drawn inside it",
+                     rail_ticks["count"] > 2
+                     and rail_ticks["outsideRange"] == []
+                     and rail_ticks["outsideCanvas"] == [],
+                     json.dumps(rail_ticks))
+
         report.check("no page errors across the whole desktop run", not page_errors,
                      " | ".join(page_errors[:2]))
 


### PR DESCRIPTION
Wave 8 of the bug audit. Two bugs, both a second mechanism disagreeing with the first. Closes #25, closes #26.

## The subject chips count things that are not on screen

`subjectCounts` was tallied at the top of `queryFacts`, before the window, the zoom band and the `part_of` roll-up had been applied to anything — so the number on each chip moved with knowledge-time and nothing else.

| view | chip says | actually drawn |
|---|---|---|
| default, all 4.6 Ga | 53 / 36 / 34 / 26 / 23 / 11 | 36 / 26 / 23 / 15 / 17 / 9 |
| zoomed to the last 60,000 years | **53 / 36 / 34 / 26 / 23 / 11** | 8 / 7 / 3 / 8 / 2 / **0** |
| knowledge-time 1800 | 1 / 0 / 0 / 0 / 0 / 0 | correct |

*(geology / chemistry / biology / human_history / evolution / astronomy)*

Identical between the first two rows. Zoom into the Holocene and the astronomy chip still advertises **11** when astronomy has nothing on screen at all — and the chip sits inside the filter control, so the number reads as "how many this brings in" and toggling it produces no visible change.

Counting a set the renderers do not draw is the second filtering path the README opens by saying does not exist. The counts now come off `visible` itself, so a chip is by construction the number of marks it accounts for.

**One thing worth flagging:** an intermediate version counted window + zoom while ignoring the subject filter, so a switched-off chip could still say what turning it on would bring in. That was wrong in the other direction — edge-recalled nodes are on screen without passing `zoomOK`, so geology read 23 against 36 drawn. Agreeing with the screen won. A switched-off subject now reads 0, which is what the screen shows; the chip is already drawn as off, so the state was never carried by the number.

## The knowledge rail types KT_MIN out four times

The drift #21 fixed on the ceiling, still present on the floor. Measured with `KT_MIN` at 1700:

```
tick loop starts at 1650    ktToY(1650) = 830px in a 737px canvas
replay span uses 376        KT_MAX - KT_MIN is 326
```

Every tick below the floor was painted outside the rail, and Replay spent its opening seconds emitting values `setKt` clamped away — the rail sat still — then covered the remaining 326 years at a rate computed for 376. `startReplay` looked right only because `setKt` clamped for it, which is a second mechanism covering for this one.

## Verification

Three new checks. Against the bugs reintroduced with the floor at 1700:

```
[FAIL] every subject chip counts the marks it accounts for
       chip {geology:53,...} drawn {geology:36,...}   all six subjects wrong, in all views
[FAIL] Replay sweeps from the floor of the rail to its ceiling
       {"start":1700,"early":1700,"end":2026,...}     early == start: the stall
71/73 checks passed
```

The tick check reads back what `drawKrail` actually paints rather than recomputing the loop bounds — a check that restates the code it checks cannot fail. With the floor at 1700 and the literal restored:

```
[FAIL] every rail tick is a year on the rail, drawn inside it
       {"KT_MIN":1700,"count":8,"outsideRange":["1650"],"outsideCanvas":["1650@830"]}
72/73 checks passed
```

All three pass with `KT_MIN` moved to 1700 on the fixed code — the property they exist for — and at the shipped floor:

```
python3 tools/validate_graph.py                 ERRORS (0)
python3 tools/check_no_local_paths.py --all     clean
python3 tools/build.py                          73/73 checks passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_