### PR TITLE
Point the asset generators at the assets the build reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Writes `earth-x-time.html` (standalone) and `artifact.html` (body-only, for a
 host that supplies its own `<head>`). ~720 KB, entirely self-contained, and the
 build refuses to finish if the smoke test fails.
 
+Each generator writes the `assets/` file the build reads, and refuses to write
+at all unless everything it needed arrived — a half-downloaded coastline would
+otherwise replace the shipped one with an empty payload and the globe would come
+up with no land on it. Two of them used to write into `tools/` instead, where
+nothing reads, so regenerating printed byte counts, exited 0, and changed
+nothing.
+
 | Asset | Source | Generator |
 |---|---|---|
 | Coastlines, plate boundaries | Natural Earth 110m land, PB2002 | `tools/fetch_coast.py` |

--- a/tools/fetch_coast.py
+++ b/tools/fetch_coast.py
@@ -1,6 +1,15 @@
-import urllib.request, json, math, os
+"""Fetch Natural Earth 110m land and the PB2002 plate boundaries.
 
-OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "coast_out.txt")
+Simplifies, quantises to 1/32 degree, and delta+zigzag+base64 encodes both into
+the single payload src/20_core.js decodes at load. Writes assets/coast.txt -
+which is what tools/build.py reads. It used to write tools/coast_out.txt, a file
+nothing has ever read, so regenerating the coastline printed its byte counts,
+exited 0, and changed nothing about the built page.
+"""
+import urllib.request, json, math, os, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUT = os.path.join(os.path.dirname(HERE), "assets", "coast.txt")
 ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-"
 SCALE = 32.0  # 1/32 degree ~ 3.5 km
 
@@ -100,6 +109,15 @@ def build(url, tol, min_area, label):
 land = build("https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/geojson/ne_110m_land.geojson", 0.42, 1.1, "land")
 plates = build("https://raw.githubusercontent.com/fraxen/tectonicplates/master/GeoJSON/PB2002_boundaries.json", 0.9, 0, "plates")
 
+# build() returns None when a download fails, and this used to write `land or ""`
+# into the file regardless. Now that the file is the one the build reads, one
+# flaky fetch would replace the shipped coastline with an empty payload and the
+# globe would come up with no land on it. Write both or write neither.
+missing = [n for n, v in (("land", land), ("plates", plates)) if not v]
+if missing:
+    sys.exit(f"FATAL: {', '.join(missing)} did not download; {OUT} left untouched")
+
+os.makedirs(os.path.dirname(OUT), exist_ok=True)
 with open(OUT, "w", encoding="utf-8") as f:
-    f.write("===LAND===\n" + (land or "") + "\n===PLATES===\n" + (plates or "") + "\n")
-print("wrote", OUT)
+    f.write("===LAND===\n" + land + "\n===PLATES===\n" + plates + "\n")
+print("wrote", OUT, f"{os.path.getsize(OUT):,} bytes")

--- a/tools/fetch_fonts.py
+++ b/tools/fetch_fonts.py
@@ -1,5 +1,12 @@
-import urllib.request, re, base64, os, json
+"""Fetch the five IBM Plex faces, latin subset, inlined as data URIs.
+
+Writes assets/fonts.css - which is what tools/build.py reads. It used to write
+tools/fonts_out.css, a file nothing has ever read, so regenerating the fonts
+printed its byte counts, exited 0, and changed nothing about the built page.
+"""
+import urllib.request, re, base64, os, json, sys
 SP = os.path.dirname(os.path.abspath(__file__))
+OUT = os.path.join(os.path.dirname(SP), "assets", "fonts.css")
 UA = {"User-Agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36"}
 
 FACES = [
@@ -11,10 +18,19 @@ FACES = [
 ]
 
 out = []
+missing = []
 total = 0
 for fam, spec, alias, wt in FACES:
     css_url = f"https://fonts.googleapis.com/css2?family={spec}&display=swap"
-    css = urllib.request.urlopen(urllib.request.Request(css_url, headers=UA), timeout=30).read().decode()
+    # A network failure used to kill the run with a traceback. It is a reason a
+    # face is missing, like any other; collect it and let the guard at the end
+    # report all of them at once.
+    try:
+        css = urllib.request.urlopen(urllib.request.Request(css_url, headers=UA), timeout=30).read().decode()
+    except Exception as e:                            # noqa: BLE001
+        print(f"SKIP {fam} {wt}: {e}")
+        missing.append(f"{fam} {wt}")
+        continue
     blocks = css.split("@font-face")
     picked = None
     for b in blocks:
@@ -25,14 +41,30 @@ for fam, spec, alias, wt in FACES:
         m = re.search(r"url\((https://[^)]+\.woff2)\)", css)
         picked = m.group(1) if m else None
     if not picked:
-        print("MISS", fam, wt); continue
-    data = urllib.request.urlopen(urllib.request.Request(picked, headers=UA), timeout=30).read()
+        missing.append(f"{fam} {wt}")
+        continue
+    try:
+        data = urllib.request.urlopen(urllib.request.Request(picked, headers=UA), timeout=30).read()
+    except Exception as e:                            # noqa: BLE001
+        print(f"SKIP {fam} {wt}: {e}")
+        missing.append(f"{fam} {wt}")
+        continue
     total += len(data)
     b64 = base64.b64encode(data).decode()
     out.append(f"@font-face{{font-family:'{alias}';font-style:normal;font-weight:{wt};font-display:block;src:url(data:font/woff2;base64,{b64}) format('woff2');}}")
     print(f"{fam} {wt} -> {len(data)} bytes raw, {len(b64)} b64")
 
-path = os.path.join(SP, "fonts_out.css")
-with open(path, "w", encoding="utf-8") as f:
+# A face that did not resolve used to be skipped and the rest written anyway.
+# Now that this file is the one the build reads, that would ship a stylesheet
+# missing a weight the page uses, and the fallback stack would quietly stand in
+# for it. All five or none.
+if missing or len(out) != len(FACES):
+    sys.exit(f"FATAL: {len(out)}/{len(FACES)} faces resolved"
+             + (f" (missing {', '.join(missing)})" if missing else "")
+             + f"; {OUT} left untouched")
+
+os.makedirs(os.path.dirname(OUT), exist_ok=True)
+with open(OUT, "w", encoding="utf-8") as f:
     f.write("\n".join(out))
-print("TOTAL raw", total, "css file", os.path.getsize(path))
+print("TOTAL raw", total, "css file", os.path.getsize(OUT))
+print("wrote", OUT)


### PR DESCRIPTION
Wave 9 of the bug audit. Closes #27.

## What was wrong

Two of the four generators named in the README's asset table wrote somewhere nothing has ever read:

| generator | wrote | build reads | |
|---|---|---|---|
| `fetch_coast.py` | `tools/coast_out.txt` | `assets/coast.txt` | ✗ |
| `fetch_fonts.py` | `tools/fonts_out.css` | `assets/fonts.css` | ✗ |
| `fetch_ics.py` | `assets/ics.json` | `assets/ics.json` | ✓ |
| `fetch_texture.py` | `assets/earth.txt` | `assets/earth.txt` | ✓ |

The failure is silent from both ends. `fetch_coast.py` downloads Natural Earth and PB2002, simplifies, encodes, prints its byte counts and exits 0 — it looks like it worked. Then `build.py` reads the old committed `assets/coast.txt` and the new coastline never reaches the page. Someone regenerating the coastline to fix a projection bug would see a successful run, an unchanged build, and nothing to explain it. Neither stray filename was in `.gitignore` either, so a run left untracked clutter beside the scripts that made it.

## Repointing them alone would have made it worse

Both were willing to write a partial result:

- `fetch_coast.py` wrote `land or ""`. One flaky download and the shipped coastline becomes an empty payload — the globe comes up with no land on it.
- `fetch_fonts.py` skipped a face it could not resolve and wrote the rest, so a stylesheet could ship missing a weight the page uses, with the fallback stack quietly standing in for it.

Both now write everything or nothing, and name the missing piece. A network error in `fetch_fonts.py` used to be an uncaught traceback rather than a reason; it is now collected like any other missing face and reported with them.

## Verification

With the downloads pointed at a closed port:

```
SKIP land: <urlopen error [Errno 111] Connection refused>
SKIP plates: <urlopen error [Errno 111] Connection refused>
FATAL: land, plates did not download; assets/coast.txt left untouched

SKIP IBM Plex Sans 400: <urlopen error [Errno 111] Connection refused>
...
FATAL: 0/5 faces resolved (missing IBM Plex Sans 400, IBM Plex Sans 600,
       IBM Plex Sans Condensed 600, IBM Plex Mono 400, IBM Plex Mono 600);
       assets/fonts.css left untouched
```

with both assets byte-identical afterwards. Then run for real — both now write the file the build reads, **and both reproduce the committed asset exactly**:

```
land: 87 rings, 1799 pts, 6615 chars
plates: 241 rings, 782 pts, 3584 chars
wrote assets/coast.txt 10,225 bytes          diff vs committed: none

IBM Plex Sans 400 -> 15980 bytes raw, 21308 b64
... 5 faces ...
wrote assets/fonts.css 102,220 bytes         diff vs committed: none
```

That last part is also the evidence that the shipped assets really did come from this pipeline — `git status` after both runs lists only the two tool files.

```
python3 tools/validate_graph.py                 ERRORS (0)
python3 tools/check_no_local_paths.py --all     clean
python3 tools/build.py                          73/73 checks passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_