### PR TITLE
Report the repair, and measure the fill that had nothing measuring it

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,10 @@ painted pixels behind the stage overlays, because a computed `background-color`
 cannot see the gradient they sit on. And it asks the page where the knowledge
 rail ends, and compares that with what the Python tools read, whether every
 subject chip counts exactly the marks it accounts for, and whether Replay
-sweeps the rail the page actually has. 73 checks, wired into `build.py`, exits
-non-zero.
+sweeps the rail the page actually has, and — by sampling the disc across
+forty-eight rotations in Chart mode — whether the filled coastline still covers
+about the 29% of Earth that is land rather than swallowing the globe. 74 checks,
+wired into `build.py`, exits non-zero.
 
 It exists because this project lost an entire build to a boot failure that
 nothing detected: a legend swatch read the wrong palette key, `undefined` reached

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -681,6 +681,66 @@ def run(url, headed, report):
                      and rail_ticks["outsideCanvas"] == [],
                      json.dumps(rail_ticks))
 
+        # ---------- 18. the filled coastline does not swallow the globe
+        # drawLandRing cuts each ring at the horizon and closes the gaps by
+        # following the limb, choosing the sweep from the ring's own orientation.
+        # The cheap alternative - collapsing hidden vertices onto the rim - turns
+        # any continent straddling the horizon into a polygon that floods the
+        # disc, and nothing here was measuring whether it does. Earth is ~29%
+        # land; a hemisphere runs from about 0.05 (mid-Pacific) to 0.55.
+        page.evaluate("""() => {
+          S.basemap = 'chart'; S.showPlates = false;
+          document.getElementById('stage').classList.remove('space');
+          S.selection = null; TW = null; changed(); renderNow();
+        }""")
+        page.wait_for_timeout(400)
+        fill = page.evaluate("""() => {
+          const g = document.getElementById('globe').getContext('2d');
+          const h = CSSV.land.replace('#', '');
+          const LR = parseInt(h.slice(0, 2), 16),
+                LG = parseInt(h.slice(2, 4), 16),
+                LB = parseInt(h.slice(4, 6), 16);
+          const fracs = [];
+          for (let lam = -180; lam < 180; lam += 30) {
+            for (const phi of [-60, -20, 20, 60]) {
+              S.rot.lam = lam; S.rot.phi = phi; needGlobe = true; renderNow();
+              const img = g.getImageData(0, 0, Math.round(GW * DPR), Math.round(GH * DPR));
+              const d = img.data, W = img.width;
+              let inDisc = 0, isLand = 0;
+              for (let i = 0; i < 48; i++) for (let j = 0; j < 48; j++) {
+                const x = Math.round((i + 0.5) * W / 48),
+                      y = Math.round((j + 0.5) * img.height / 48);
+                const dx = x / DPR - GCX, dy = y / DPR - GCY;
+                if (dx * dx + dy * dy > (GR * 0.93) * (GR * 0.93)) continue;
+                inDisc++;
+                const k = (y * W + x) * 4;
+                if (Math.abs(d[k] - LR) < 14 && Math.abs(d[k + 1] - LG) < 14 &&
+                    Math.abs(d[k + 2] - LB) < 14) isLand++;
+              }
+              if (inDisc > 100) fracs.push({ lam, phi, f: isLand / inDisc });
+            }
+          }
+          const fs = fracs.map(x => x.f);
+          const worst = fracs.slice().sort((a, b) => b.f - a.f)[0];
+          return {
+            views: fracs.length,
+            min: +Math.min(...fs).toFixed(3),
+            max: +Math.max(...fs).toFixed(3),
+            mean: +(fs.reduce((a, b) => a + b, 0) / fs.length).toFixed(3),
+            worst: worst && { lam: worst.lam, phi: worst.phi, f: +worst.f.toFixed(3) }
+          };
+        }""")
+        report.check("the filled coastline never floods the globe",
+                     fill["views"] >= 40 and fill["max"] <= 0.70
+                     and fill["min"] >= 0.005 and 0.18 <= fill["mean"] <= 0.40,
+                     json.dumps(fill))
+        page.evaluate("""() => {
+          S.basemap = 'satellite'; S.showPlates = true;
+          document.getElementById('stage').classList.add('space');
+          S.rot.lam = 30; S.rot.phi = 12; changed(); renderNow();
+        }""")
+        page.wait_for_timeout(300)
+
         report.check("no page errors across the whole desktop run", not page_errors,
                      " | ".join(page_errors[:2]))
 

--- a/tools/validate_graph.py
+++ b/tools/validate_graph.py
@@ -268,7 +268,22 @@ def main():
         if len(zb) != 2 or zb[0] > zb[1]:
             warns.append(f"{w}: bad zoom_band {zb} -> [0,10]")
             c["zoom_band"] = [0, 10]
-        c["significance"] = max(1, min(5, int(c.get("significance", 3))))
+        # significance decides marker radius on both the globe and the timeline,
+        # and >=5 overrides the zoom band outright, so a value quietly rewritten
+        # is a rendering decision made behind the author. Every other repair in
+        # this loop reports itself; this one used to rewrite the file and say
+        # nothing, and a non-numeric one was a traceback rather than an error
+        # line naming the claim.
+        raw = c.get("significance", 3)
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            errors.append(f"{w}: significance {raw!r} is not a number")
+            c["significance"] = 3
+        else:
+            sig = max(1, min(5, int(raw)))
+            if sig != raw:
+                warns.append(f"{w}: significance {raw} -> {sig}")
+                fixes.append(c["id"])
+            c["significance"] = sig
 
     # ---- edges ------------------------------------------------------------
     seen_edge = set()


### PR DESCRIPTION
Wave 10 of the bug audit. One fix and one measurement. Closes #30.

## validate_graph.py rewrote significance and said nothing

Set one claim to `significance: 9` and run the validator:

```
claim: clm_earth_accretion_patterson, authored with significance 9
lines mentioning it or "significance": NONE
WARNINGS (1)                       <- the pre-existing coordinate warning, nothing else
value written back to src/graph.json: 5
```

The file on disk comes back changed with nothing said. Every other repair in that loop reports itself — the timeline sort, the `knowledge_time` alignment, the `zoom_band` reset, the duplicate-referent merge — and this one, two lines below the `zoom_band` warning, did not.

It is not a decorative field. `queryFacts` uses `res.significance >= 5` to override the zoom band outright, and both renderers size their markers from it. Someone writing 9 to force something prominent got 5, with no sign that the number they chose was not the number used.

An unreadable one was a traceback rather than an error line naming the claim — the same shape as #23:

| authored | before | after |
|---|---|---|
| `9` | silently 5 | stored 5, `~ claim …: significance 9 -> 5` |
| `0` | silently 1 | stored 1, `~ claim …: significance 0 -> 1` |
| `3.7` | silently 3 | stored 3, `~ claim …: significance 3.7 -> 3` |
| `'high'` | `ValueError: invalid literal for int()` | `! claim …: significance 'high' is not a number`, rc=1 |
| `None` | `TypeError: int() argument must be … not 'NoneType'` | `! claim …: significance None is not a number`, rc=1 |
| `4` | unchanged | unchanged, nothing said |

## The globe's limb fill had nothing measuring it

`drawLandRing` is the most intricate code in the project: it cuts each ring at the horizon and closes the gaps by following the limb, choosing the sweep direction from the ring's own orientation. The cheap alternative — collapsing hidden vertices onto the rim — turns any continent straddling the horizon into a polygon that swallows the disc. No existing check would have noticed.

Sampled across 48 rotations in Chart mode, it is **correct**:

```
land fraction  min 0.045   max 0.533   mean 0.263
```

against Earth's true 29% land, with a hemisphere ranging from about 0.05 (mid-Pacific) to 0.55 (Africa/Eurasia). The highest readings are at high northern latitudes over North America and Eurasia, which is genuinely the most land-heavy view.

That is now asserted rather than assumed. The check was verified by reintroducing exactly that mistake:

```
[FAIL] the filled coastline never floods the globe
       {"views":48,"min":0.122,"max":0.999,"mean":0.453,"worst":{"lam":150,"phi":-20,"f":0.999}}
73/74 checks passed
```

A disc 99.9% land at one rotation, and the mean pushed from 0.263 to 0.453.

## Verification

```
python3 tools/validate_graph.py                 ERRORS (0)
python3 tools/check_no_local_paths.py --all     clean
python3 tools/build.py                          74/74 checks passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_