### PR TITLE
Do the triage the warning has been asking for, and refuse the last four crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ understood in 2026, that the K–Pg date is disputed in 1970 and settled now, th
 consensus and newest resolvers disagree somewhere, and that Chicxulub → K–Pg is
 absent in 1975 and live by 1985. It exits non-zero on any of those.
 
+Its offshore-coordinate check used to warn about the same 29 points on every
+run, asking for a verification it gave nowhere to record — so it said the same
+thing forever, and a genuine typo would have been item 30 in a list of 29
+known-good ones. The triage is now in the file: six sites, each with its reason
+and its measured distance to the shipped coastline. Four are on land and inside
+the ~46 km a 0.42° simplification can move a coast (Siccar Point 1.2 km,
+Nuvvuagittuq 2.9, the Newfoundland base-Cambrian section 4.5, Senlac Hill ~20);
+Chicxulub's crater centre is genuinely half offshore; and Santorini reads 182 km
+out because the island is not in the 110m dataset at all. Anything else is
+reported with its distance, which says whether it is a headland or a sign error.
+
 Those assertions run through a `resolve()` that mirrors `src/30_model.js` line
 for line, because for a while they did not, and a gate that asks a different
 question is not a gate: it reported 24 resolver movers where the page moves 28,

--- a/tools/apply_patch.py
+++ b/tools/apply_patch.py
@@ -59,6 +59,31 @@ def main():
     new_edges = patch.get("edges", [])
     removals = patch.get("removals", [])
 
+    # ---------------------------------------------------------- identifiers
+    # Everything below indexes these by name to say WHICH thing is wrong, so a
+    # missing one used to be a KeyError naming a dict key - no id, no referent,
+    # nothing an agent reading the output could act on. Entries without an id
+    # are reported and then dropped, so one missing field does not hide the
+    # rest of the report.
+    def _identified(items, field, what):
+        ok = []
+        for i, it in enumerate(items):
+            if not isinstance(it, dict) or not str(it.get(field) or "").strip():
+                err(f"{what} #{i + 1} has no {field}")
+            else:
+                ok.append(it)
+        return ok
+
+    new_refs = _identified(new_refs, "id", "new referent")
+    new_claims = _identified(new_claims, "id", "new claim")
+    new_edges = _identified(new_edges, "id", "edge")
+    removals = _identified(removals, "edge_id", "removal")
+    # `why` is only ever read in the report, which runs after the graph has been
+    # mutated - so a removal without one printed the success line and then died.
+    for r in removals:
+        if not str(r.get("why") or "").strip():
+            err(f"removal {r['edge_id']} has no `why` - a removal has to say what it is for")
+
     # ------------------------------------------------------------- collisions
     seen = set()
     for r in new_refs:

--- a/tools/validate_graph.py
+++ b/tools/validate_graph.py
@@ -167,6 +167,58 @@ def on_land(lat, lng, rings):
     return inside
 
 
+def km_to_coast(lat, lng, rings):
+    """Great-circle-ish distance to the nearest coastline vertex, in km.
+
+    Not the on_land test - that one is a ray cast, and distance is a bad
+    membership test for the reason on_land's docstring gives. This is here only
+    to describe a point that has ALREADY been flagged, because the number says
+    which kind of flag it is: a few km is a headland the 0.42-degree
+    simplification has swallowed, a few hundred is an island missing from the
+    110m dataset, and a few thousand is a sign error.
+    """
+    k = math.cos(math.radians(lat))
+    best = float("inf")
+    for ring in rings:
+        n = len(ring)
+        for i in range(n):
+            ax, ay = ring[i]
+            bx, by = ring[(i + 1) % n]
+            if abs(bx - ax) > 180:                    # the antimeridian seam
+                continue
+            ax, ay = (ax - lng) * k, ay - lat
+            bx, by = (bx - lng) * k, by - lat
+            dx, dy = bx - ax, by - ay
+            t = 0.0 if dx == dy == 0 else max(0.0, min(1.0, (-ax * dx - ay * dy) / (dx * dx + dy * dy)))
+            d = math.hypot(ax + t * dx, ay + t * dy)
+            if d < best:
+                best = d
+    return best * 111.32
+
+
+# Coordinates that read as offshore and have been checked, each with the reason
+# and the measured distance to the shipped coastline. The warning used to fire
+# on all 29 of these on every run, asking for a verification it gave nowhere to
+# record - so it said the same thing forever, and a genuine typo would have been
+# item 30 in a list of 29 known-good ones. Keyed by referent and coordinate
+# rounded to 0.1 degree, which is ~11 km: tight enough that a transposed digit
+# moves off the key, loose enough to survive a re-measured site.
+VERIFIED_OFFSHORE = {
+    ("earth_formation", 55.9, -2.3):
+        "Hutton's unconformity at Siccar Point - a coastal promontory, 1.2 km out",
+    ("origin_of_life", 58.3, -77.7):
+        "Nuvvuagittuq, eastern Hudson Bay shore (Dodd et al. 2017) - 2.9 km out",
+    ("cambrian_explosion", 47.1, -55.8):
+        "base-Cambrian section, Newfoundland (Linnemann et al. 2019) - 4.5 km out",
+    ("battle_of_hastings", 50.9, 0.5):
+        "Senlac Hill, East Sussex - inland, but the 0.42 degree coastline is ~20 km off here",
+    ("chicxulub_impact", 21.4, -89.5):
+        "crater centre on the north Yucatan coast - genuinely half offshore",
+    ("thera_eruption", 36.4, 25.4):
+        "the Santorini caldera - water by definition, and the island is absent from 110m",
+}
+
+
 def main():
     # Defaults to the live graph. It used to require a path because it was
     # written to check generated clusters before they were merged; running it on
@@ -324,13 +376,21 @@ def main():
     # centre, Thera's caldera). Only flag what no simplification explains.
     land = load_land()
     if land:
-        wet = []
+        wet, checked = [], 0
         for c in claims:
             gm = c["geometry"]
             if gm["mode"] != "point" or gm.get("lat") is None:
                 continue
-            if not on_land(gm["lat"], gm["lng"], land):
-                wet.append(f"{c['id']} ({c['about']}) at {gm['lat']:.2f},{gm['lng']:.2f}")
+            if on_land(gm["lat"], gm["lng"], land):
+                continue
+            root = c["about"] if c["about"] in rid else (cid.get(c["about"], {}) or {}).get("about")
+            key = (root, round(gm["lat"], 1), round(gm["lng"], 1))
+            if key in VERIFIED_OFFSHORE:
+                checked += 1
+                continue
+            wet.append(f"{c['id']} ({c['about']}) at {gm['lat']:.2f},{gm['lng']:.2f} "
+                       f"— {km_to_coast(gm['lat'], gm['lng'], land):,.0f} km from the "
+                       f"nearest coast")
         if wet:
             warns.append(f"{len(wet)} point coordinate(s) fall in water — verify each is "
                          f"genuinely offshore (a crater centre, a caldera, a drill site) "
@@ -419,6 +479,9 @@ def main():
     print(f"types:    " + str(collections.Counter(c['type'] for c in claims)))
     print(f"subjects: " + str(collections.Counter(s for c in claims for s in c['subjects'])))
     kt = [c["knowledge_time"] for c in claims]
+    if land:
+        print(f"offshore coordinates: {checked} verified "
+              f"({len(VERIFIED_OFFSHORE)} sites), {len(wet)} unaccounted for")
     print(f"knowledge_time span {min(kt)}–{max(kt)}  "
           f"(rail {KT_MIN}..{KT_MAX}, read from src/20_core.js)")
     print(f"resolver movers (consensus vs frontier): {len(movers)}")


### PR DESCRIPTION
Wave 11 of the bug audit. Closes #32, closes #33.

## A warning that could never change

The offshore-coordinate check asked, on every run since the project began, for a verification it gave nowhere to record. So it printed the same 29 items forever — and a real typo would have arrived as item 30 in a list of 29 known-good ones. A warning that never changes teaches the reader to skip the section the next finding will appear in.

Here is the triage, done, and written down beside the check. 29 claims at six sites, each measured against the shipped coastline:

| referent | lat, lng | km to coast | what it is |
|---|---|---|---|
| earth_formation | 55.93, −2.30 | **1.2** | Siccar Point — Hutton's unconformity |
| origin_of_life | 58.28, −77.73 | **2.9** | Nuvvuagittuq, Hudson Bay shore (Dodd et al. 2017) |
| cambrian_explosion | 47.08, −55.82 | **4.5** | base-Cambrian section, Newfoundland (Linnemann et al. 2019) |
| battle_of_hastings | 50.9, 0.49 | **~20** | Senlac Hill, East Sussex |
| chicxulub_impact | 21.40, −89.50 | **~30** | crater centre, north Yucatán |
| thera_eruption | 36.40, 25.40 | **182** | the Santorini caldera |

**No typos.** And the distances sort the cases by themselves:

- The first four are inside the ~46 km a 0.42° simplification can move a coast. They are on land; the coastline is what is wrong.
- Chicxulub's centre is genuinely half offshore — already named in the README as a legitimate case.
- Thera reads 182 km out not as a near-miss but because Santorini is **absent from the 110m dataset entirely**, so the nearest coast it can find is the mainland.

The count now reads 0, and the report says `offshore coordinates: 29 verified (6 sites), 0 unaccounted for` so a silent check is not mistaken for no check. Anything off the list is printed with its distance, which says whether it is a headland or a sign error.

Verified both ways — flipping Chicxulub's longitude, and separately drifting its latitude 0.5°:

```
offshore coordinates: 28 verified (6 sites), 1 unaccounted for
~ 1 point coordinate(s) fall in water … clm_chicxulub_date_66043 at 21.40,89.50 — 40 km from the nearest coast
~ 1 point coordinate(s) fall in water … clm_chicxulub_date_66043 at 21.90,-89.50 — 85 km from the nearest coast
```

## Four more of the crash #23 fixed one instance of

`apply_patch.py` read identifying fields with `[...]` before establishing they exist:

| patch contains | before |
|---|---|
| an edge with no `id` | `KeyError: 'id'` |
| a new referent with no `id` | `KeyError: 'id'` |
| a removal with no `edge_id` | `KeyError: 'edge_id'` |
| a removal with no `why` | **passes validation, prints `-1 edges`, then `KeyError: 'why'`** |

The last is the bad one. `why` was read only in the reporting loop, which runs after the in-memory graph has been mutated, so the operator saw the summary that means it worked followed by a stack trace. Nothing was written — the `--write` block comes later — but nothing said so either, and answering "was that applied or not" is the whole job.

All four are error lines now, and an entry with no id is reported and skipped rather than indexed into, so one missing field no longer hides the rest of the report:

```
edge #1 has no id
new referent #1 has no id
removal #1 has no edge_id
removal edg_moon_impact_part_of_accretion has no `why` - a removal has to say what it is for
```

with a valid patch still applying.

## Verification

```
python3 tools/validate_graph.py                 WARNINGS (0)   ERRORS (0)
python3 tools/check_no_local_paths.py --all     clean
python3 tools/build.py                          74/74 checks passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_