### PR TITLE
Stop ingest.py from destroying its own output

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ labels and subject hints. It is not a source of *sourced dates*.
 Referents adopt a QID, so re-running merges instead of minting
 `deccan_traps_2` beside `deccan_traps`. Matching is by QID first, then label.
 
+The output file is a review queue, so it is merged into rather than replaced:
+ingesting one more item keeps the work already in it, and a run that ingested
+nothing refuses to write at all rather than leaving an empty file behind. It
+used to do neither — `--out` defaults to `src/ingested.json`, the write was
+unconditional, and one mistyped name emptied ten referents and exited 0.
+
+A failure to reach Wikidata is reported separately from the no-source-no-fact
+rule, and a run with any failure exits non-zero. Those are different facts: one
+is this tool's own discipline working, the other is not having looked.
+
 **What it deliberately does not do** is author the `status_timeline`. I tested
 the obvious idea — read consensus formation off citation history — and it fails:
 

--- a/tools/ingest.py
+++ b/tools/ingest.py
@@ -459,8 +459,15 @@ def main():
             if r.get("wikidata"):
                 existing_by_qid[r["wikidata"]] = r["id"]
 
-    report = {"dropped": [], "needs_subjects": [], "no_geometry": [], "links": [],
-              "counts": {"referents": 0, "time_statements": 0, "with_reference": 0, "resolved": 0}}
+    # `failed` is deliberately not `dropped`. A drop is this tool's own rule
+    # working - Wikidata had a date and no reference, so no claim. A failure is
+    # the network, or a typo in the name. Filing them together means the output
+    # cannot answer "did Wikidata have nothing, or did we not look", which is
+    # the one distinction this tool exists to make.
+    report = {"dropped": [], "failed": [], "needs_subjects": [], "no_geometry": [],
+              "links": [],
+              "counts": {"requested": len(args.qids), "referents": 0,
+                         "time_statements": 0, "with_reference": 0, "resolved": 0}}
     referents, claims = [], []
     for term in args.qids:
         term = term.strip()
@@ -474,7 +481,7 @@ def main():
             ref, cls = ingest_qid(qid, existing_by_qid, existing_ids, report)
         except Exception as e:                       # noqa: BLE001
             print(f"  FAILED: {type(e).__name__}: {e}")
-            report["dropped"].append(f"{term}: fetch failed — {e}")
+            report["failed"].append(f"{term}: {type(e).__name__}: {e}")
             continue
         existing_ids.add(ref["id"])
         referents.append(ref)
@@ -489,23 +496,74 @@ def main():
             print(f"    {'':12}  doi:{c['_doi'] or '—'}  via {c['_resolved_via']}  "
                   f"cited-by {c['_cited_by']}")
 
-    out = {"referents": referents, "claims": claims, "edges": [],
+    # ------------------------------------------------------------------ write
+    # This file is a review queue - its own _note says every claim in it needs a
+    # status_timeline authored before it can be merged - so it holds work, and
+    # the run used to replace it wholesale. Ingesting one more item took it from
+    # ten referents to one, and a single mistyped name took it to zero and
+    # exited 0. Merge by referent id, and never write nothing over something.
+    prior = {"referents": [], "claims": [], "edges": []}
+    if os.path.exists(args.out):
+        try:
+            with open(args.out, encoding="utf-8") as fh:
+                loaded = json.load(fh)
+            # Readable JSON is not enough - it has to be THIS tool's file.
+            # Anything else at --out is the user pointing somewhere they did not
+            # mean to, and writing over it is the same destruction in a
+            # different costume.
+            if not isinstance(loaded, dict) or not any(
+                    isinstance(loaded.get(k), list) for k in ("referents", "claims")):
+                sys.exit(f"FATAL: {args.out} exists and is not an ingest output "
+                         f"(no `referents` or `claims` list); refusing to overwrite it. "
+                         f"Move it aside or pass --out somewhere else.")
+            for k in ("referents", "claims", "edges"):
+                if isinstance(loaded.get(k), list):
+                    prior[k] = loaded[k]
+        except (OSError, ValueError) as e:
+            sys.exit(f"FATAL: {args.out} exists but could not be read ({e}). "
+                     f"Move it aside or pass --out somewhere else; refusing to "
+                     f"overwrite a file this run cannot merge with.")
+
+    if not referents and (prior["referents"] or prior["claims"]):
+        sys.exit(f"FATAL: nothing was ingested"
+                 + (f" ({len(report['failed'])} of {len(args.qids)} item(s) failed)"
+                    if report["failed"] else "")
+                 + f"; {args.out} left untouched "
+                 f"({len(prior['referents'])} referent(s), {len(prior['claims'])} claim(s)).")
+
+    touched = {r["id"] for r in referents}
+    kept_refs = [r for r in prior["referents"] if r.get("id") not in touched]
+    kept_claims = [c for c in prior["claims"] if c.get("about") not in touched]
+    replaced = len(prior["referents"]) - len(kept_refs)
+
+    out = {"referents": kept_refs + referents,
+           "claims": kept_claims + claims,
+           "edges": prior["edges"],
            "_report": report,
            "_note": "Every claim here is _review:true with a one-entry status_timeline. "
                     "The proposed/contested/consensus arc is NOT derivable from any API "
                     "and must be authored before merging."}
-    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
     json.dump(out, open(args.out, "w", encoding="utf-8"), indent=1, ensure_ascii=False)
 
     print("\n" + "=" * 68)
     print(f"referents {len(referents)}   claims {len(claims)}   -> {args.out}")
+    print(f"  merged: {len(referents) - replaced} added, {replaced} replaced, "
+          f"{len(kept_refs)} kept from previous runs "
+          f"-> {len(out['referents'])} referent(s), {len(out['claims'])} claim(s) in the file")
     print(f"resolved by DOI: {sum(1 for c in claims if c['_resolved_via']=='doi')}   "
           f"by title search: {sum(1 for c in claims if c['_resolved_via']=='title-search')}   "
           f"Wikidata-only: {sum(1 for c in claims if c['_resolved_via']=='wikidata-only')}")
     c = report["counts"]
     pct = 100 * c["resolved"] // max(1, c["time_statements"])
+    # Say how many items were ASKED for, not just how many answered. The README
+    # quotes this line as its finding about Wikidata; a run where two of ten
+    # items 404 used to report the percentage over the eight and name the ten
+    # nowhere.
+    reach = (f"{c['referents']} of {c['requested']} items"
+             if c["referents"] != c["requested"] else f"{c['referents']} items")
     print(f"\nWIKIDATA COVERAGE: {c['time_statements']} dated statements across "
-          f"{c['referents']} items -> {c['with_reference']} carry any reference "
+          f"{reach} -> {c['with_reference']} carry any reference "
           f"-> {c['resolved']} resolve to a citation ({pct}%).")
     print("  Wikidata is dependable for identity, coordinates and labels.")
     print("  It is NOT a source of sourced dates: most date statements cite nothing.")
@@ -515,9 +573,14 @@ def main():
         for l in report["links"]:
             print("  -", l)
 
-    print(f"\nDROPPED ({len(report['dropped'])}) — mostly the no-source-no-fact rule:")
+    print(f"\nDROPPED ({len(report['dropped'])}) — the no-source-no-fact rule:")
     for d in report["dropped"][:12]:
         print("  -", d)
+    if report["failed"]:
+        print(f"\nFAILED ({len(report['failed'])}) — not a finding about the record, "
+              f"a failure to read it:")
+        for f in report["failed"]:
+            print("  -", f)
     if report["needs_subjects"]:
         print(f"\nNEEDS SUBJECTS ({len(report['needs_subjects'])}):")
         for s in report["needs_subjects"]:
@@ -527,6 +590,13 @@ def main():
     print("\nNext: author the status_timeline for each claim, then merge into "
           "src/graph.json and re-run tools/validate_graph.py.")
 
+    # A batch that half-failed is not a success. Anything driving this - a
+    # script, an agent - needs the exit code to say so; the file was written,
+    # so the successful half is not lost either way.
+    if report["failed"]:
+        return 1
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main() or 0)


### PR DESCRIPTION
Wave 13 of the bug audit — `tools/ingest.py`, the largest surface in the repo that had never been run. Closes #38.

## One mistyped name empties the file

`--out` defaults to the committed `src/ingested.json`, and the write at the end of `main()` was unconditional. Reproduced against the real file:

```
before   10 referents, 1 claim
         ['chicxulub_crater', 'cretaceous_paleogene_mass_extinction',
          'permian_triassic_mass_extinction', 'siberian_traps', 'deccan_traps',
          'great_oxygenation_event', 'minoan_eruption', 'jebel_irhoud',
          'snowball_earth', 'battle_of_hastings']

$ python3 tools/ingest.py "zzzqqq not a real thing xyzzy"
  FAILED: LookupError: no Wikidata item matches 'zzzqqq not a real thing xyzzy'
referents 0   claims 0   -> /home/user/earth-x-time/src/ingested.json
exit=0

after    0 referents, 0 claims
```

Ten referents and the one hard-won resolved claim, gone on a typo, exit 0 — and reachable from the invocation the README documents, which shows no `--out`.

**The successful form is the same bug.** A run replaced rather than merged, so ingesting one more item took the file from ten referents to one. That file's own `_note` says every claim in it needs a `status_timeline` authored before it can be merged into the graph — it is a review queue, so it holds work. The tool already takes idempotency seriously in the *other* direction, reading `graph.json` to adopt an existing referent's QID rather than minting `deccan_traps_2`; it applied none of that care to its own output.

## Two smaller things in the same area

**A fetch failure was filed under the no-source-no-fact rule**, in a list headed `DROPPED (2) — mostly the no-source-no-fact rule`:

```
- zzzqqq not a real thing: fetch failed — no Wikidata item matches ...
- Q837561 P585 (2,450,002,025 ybp): NO REFERENCE — no source, no fact
```

Those are opposite facts — one is this tool's discipline working, the other is not having looked — in the one tool whose entire purpose is telling them apart.

**The coverage line counted only the items that answered.** A three-item run with one failure printed `across 2 items`. The README quotes that statistic as its main finding about Wikidata; had two of its ten failed, the number would have been computed over eight and said ten nowhere.

## After

```
$ python3 tools/ingest.py "zzzqqq not a real thing xyzzy"
FATAL: nothing was ingested (1 of 1 item(s) failed); src/ingested.json left
       untouched (10 referent(s), 1 claim(s)).                          exit=1

$ python3 tools/ingest.py "Deccan Traps"
  merged: 0 added, 1 replaced, 9 kept from previous runs
          -> 10 referent(s), 1 claim(s) in the file                     exit=0

$ python3 tools/ingest.py "Siberian Traps" "zzzqqq not real"
  merged: 0 added, 1 replaced, 9 kept from previous runs
WIKIDATA COVERAGE: 0 dated statements across 1 of 2 items -> ...
DROPPED (0) — the no-source-no-fact rule:
FAILED (1) — not a finding about the record, a failure to read it:
  - zzzqqq not real: LookupError: no Wikidata item matches 'zzzqqq not real'   exit=1
```

It also refuses when the existing `--out` is unreadable, or is readable JSON that is not an ingest output — writing over a file the user pointed at by mistake is the same destruction in a different costume:

```
FATAL: /tmp/bad.json exists but could not be read (Expecting value: line 1 column 1).
FATAL: /tmp/shape.json exists and is not an ingest output (no `referents` or `claims` list);
       refusing to overwrite it.
```

both leaving the file intact.

## Verification

Every case above was run against the real `src/ingested.json` (restored from git afterwards — regenerating it is not part of this fix, and `git status` confirms it is unchanged).

```
python3 tools/validate_graph.py                 WARNINGS (0)   ERRORS (0)
python3 tools/check_no_local_paths.py --all     clean
python3 tools/build.py                          77/77 checks passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_