### PR TITLE
Make the two merge tools agree on the safe default, and check what they claim to

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,16 @@ rewrote a 2026 citation's year to 2025, and the rail's own button and ARIA
 range still advertised the old year. Moving the ceiling is one edit now, and
 the smoke test compares the running page with what the tools read.
 
+Two tools merge authored content into `src/graph.json`, and they now agree on
+the safe default: both `tools/apply_patch.py` and `tools/stage4_merge.py` are a
+dry run unless you pass `--write`. `stage4_merge.py` used to be the other way
+round, so confusing the two wrote to the committed graph when you meant to see
+a plan. Its own per-claim check also now covers `significance`, `zoom_band` and
+`time_precision` — all three were in its required-fields list and none of their
+values was ever looked at, against a docstring promising the same rules the
+validator enforces. It points at the validator before the build, because
+`build.py` does not validate.
+
 `tools/validate_graph.py` is a gate, not a formatter. It checks referential
 integrity, schema discipline and coordinate sanity, and it asserts the product's
 own promises: that the required cross-domain causal chain is wired end to end,

--- a/tools/stage4_merge.py
+++ b/tools/stage4_merge.py
@@ -1,14 +1,21 @@
 """
 Merge stage-4 authored claims into the graph.
 
-    python tools/stage4_merge.py <workflow-output.json> [--dry-run]
+    python tools/stage4_merge.py <workflow-output.json>           # dry run
+    python tools/stage4_merge.py <workflow-output.json> --write
 
-Takes the output of the author-status workflow, checks it against the same rules
-tools/validate_graph.py enforces, attaches the referents that tools/ingest.py
-resolved (with their Wikidata QIDs), and writes src/graph.json.
+Takes the output of the author-status workflow, checks each claim against the
+per-claim rules tools/validate_graph.py enforces, attaches the referents that
+tools/ingest.py resolved (with their Wikidata QIDs), and writes src/graph.json.
 
 Refuses to merge anything that would violate the schema, and reports what it
 rejected rather than quietly dropping it.
+
+It is a per-CLAIM check only: referential integrity across the whole graph, the
+narrative gates, and the coordinate triage all live in tools/validate_graph.py,
+which is why that is the next step and not build.py. Claiming more than this is
+what let significance "high", zoom_band [10,0] and a negative time_precision
+merge clean.
 """
 import json, os, sys, argparse, collections, html
 
@@ -79,6 +86,28 @@ def check(c, known_referents):
         for e in st:
             if e["status"] not in STATUSES:
                 bad.append(f"bad status {e['status']}")
+    # REQUIRED lists these three, and nothing validated their values, so a
+    # claim carrying significance "high", zoom_band [10,0] or a negative
+    # time_precision merged clean - against a docstring promising the same rules
+    # validate_graph.py enforces.
+    sig = c.get("significance")
+    if isinstance(sig, bool) or not isinstance(sig, (int, float)):
+        bad.append(f"significance {sig!r} is not a number")
+    elif not (1 <= sig <= 5):
+        bad.append(f"significance {sig} outside 1-5")
+    zb = c.get("zoom_band")
+    if (not isinstance(zb, list) or len(zb) != 2
+            or not all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in zb)
+            or zb[0] > zb[1]):
+        bad.append(f"bad zoom_band {zb!r}")
+    tp = c.get("time_precision")
+    if isinstance(tp, bool) or not isinstance(tp, (int, float)):
+        bad.append(f"time_precision {tp!r} is not a number")
+    elif tp < 0:
+        # A negative one inverts resolve()'s envelope - oldest ends up younger
+        # than youngest - and the panel prints "+/- -5000 yr".
+        bad.append(f"time_precision {tp} is negative")
+
     gm = c.get("geometry") or {}
     if gm.get("mode") in ("point", "region"):
         if gm.get("lat") is None or gm.get("lng") is None:
@@ -93,7 +122,15 @@ def main():
     ap.add_argument("workflow_output")
     ap.add_argument("--ingested", default=os.path.join(ROOT, "src", "ingested.json"))
     ap.add_argument("--graph", default=os.path.join(ROOT, "src", "graph.json"))
-    ap.add_argument("--dry-run", action="store_true")
+    # Dry run by default, like tools/apply_patch.py. It used to be the other
+    # way round: two tools in this directory merge authored content into
+    # src/graph.json, and they had opposite defaults, so confusing them wrote to
+    # the committed graph when you meant to see a plan. --dry-run is still
+    # accepted and still means what it says.
+    ap.add_argument("--write", action="store_true",
+                    help="apply the merge; without it this is a dry run")
+    ap.add_argument("--dry-run", action="store_true",
+                    help=argparse.SUPPRESS)
     a = ap.parse_args()
 
     wf = unescape(load_workflow(a.workflow_output))
@@ -177,8 +214,8 @@ def main():
         for cid, about, probs in rejected[:15]:
             print(f"  {cid} ({about}): {'; '.join(probs)}")
 
-    if a.dry_run:
-        print("\n--dry-run: nothing written.")
+    if a.dry_run or not a.write:
+        print("\n(dry run; pass --write to apply)")
         return 0
 
     graph["claims"].extend(merged)
@@ -186,7 +223,11 @@ def main():
               separators=(",", ":"), ensure_ascii=False)
     print(f"\nwrote {a.graph}: {len(graph['referents'])} referents, "
           f"{len(graph['claims'])} claims, {len(graph['edges'])} edges")
-    print("Next: python tools/build.py")
+    # validate_graph.py is the gate; check() above is only a per-claim subset of
+    # it and says nothing about referential integrity across the whole graph.
+    # Pointing straight at build.py, which does not validate, let a malformed
+    # merge reach the built page unchallenged.
+    print("Next: python tools/validate_graph.py, then python tools/build.py")
     return 0
 
 

--- a/tools/validate_graph.py
+++ b/tools/validate_graph.py
@@ -316,6 +316,19 @@ def main():
                     errors.append(f"{w}: lat {gm['lat']} out of range")
                 if not (-180 <= gm["lng"] <= 180):
                     errors.append(f"{w}: lng {gm['lng']} out of range")
+        # Neither this file nor stage4_merge.py looked at time_precision. A
+        # negative one inverts the envelope resolve() builds - oldest comes out
+        # younger than youngest - and the panel renders "+/- -5000 yr" beside a
+        # span of "-10,000 years".
+        tp = c.get("time_precision")
+        if isinstance(tp, bool) or not isinstance(tp, (int, float)):
+            errors.append(f"{w}: time_precision {tp!r} is not a number")
+            c["time_precision"] = 0
+        elif tp < 0:
+            errors.append(f"{w}: time_precision {tp} is negative — it would invert the band")
+        elif tp > 4.6e9:
+            errors.append(f"{w}: time_precision {tp} is wider than the age of the Earth")
+
         zb = c.get("zoom_band") or [0, 10]
         if len(zb) != 2 or zb[0] > zb[1]:
             warns.append(f"{w}: bad zoom_band {zb} -> [0,10]")


### PR DESCRIPTION
Wave 14 of the bug audit — `tools/stage4_merge.py`, which had never been run. Closes #40.

## Opposite defaults for the same job

Two tools in `tools/` merge authored content into `src/graph.json`, and they disagreed about which way is safe — both documented that way:

```
apply_patch.py  patch.json              # dry run, --write applies
stage4_merge.py <workflow.json>         # WRITES, --dry-run previews
```

Confuse them and you have written to the committed graph when you meant to see a plan. `stage4_merge.py` is a dry run now, with `--write` to apply; `--dry-run` is still accepted and still means what it says.

## The check it advertised is not the check it did

Its docstring promised *"checks it against the same rules `tools/validate_graph.py` enforces"*. Fed five claims — one valid, four the validator objects to:

```
stage-4 claims in     5
  merged              5
  rejected            0
```

`significance`, `zoom_band` and `time_precision` are all three in its `REQUIRED` list and none of their values was ever looked at:

| field | what validate_graph does | stage4 did |
|---|---|---|
| `significance: "high"` | error, exits non-zero | merged |
| `significance: 99` | warns, clamps to 5 | merged |
| `zoom_band: [10, 0]` | warns, repairs | merged |
| `time_precision: -5000` | **nothing — neither tool checked it** | merged |

After:

```
  merged              1
  rejected            4
REJECTED — not merged:
  clm_audit_sig_string (earth_formation): significance 'high' is not a number
  clm_audit_sig_huge   (earth_formation): significance 99 outside 1-5
  clm_audit_zoom_bad   (earth_formation): bad zoom_band [10, 0]
  clm_audit_prec_neg   (earth_formation): time_precision -5000 is negative
(dry run; pass --write to apply)
```

The docstring now says what the check *is* — per-claim only, with referential integrity and the narrative gates living in the validator — because claiming more than it did is what let the four through.

## What a negative time_precision actually does

Stated exactly, because it is less dramatic than it sounds. `resolve()` builds the envelope as `max(start + p)` / `min(end − p)` across the pool, so on a referent with rival datings one negative precision is **absorbed** — measured, the band did not move at all. On a referent whose only dating claim carries one, the envelope inverts:

```
oldest 99,995,000    youngest 100,005,000    width -10,000
panel:  "± -5000 yr"        band: "-10,000 years" of disagreement
drawn band width: 0 px
```

No crash, and the canvas draws nothing corrupt. It is a nonsense reading, not a broken page. It now fails in `validate_graph.py` as well, which is the actual gate.

## And the documented next step did not catch any of it

After writing, stage4 printed `Next: python tools/build.py`, and `build.py` does not validate. It points at `validate_graph.py` first now, the way `apply_patch.py` already did.

## Verification

```
default run    4 rejected / 1 merged, target graph untouched at 275 claims
--write        applies, reaches 276, and prints the validator as the next step
--dry-run      still honoured, writes nothing

validate_graph, time_precision:
  -5000    rc=1  time_precision -5000 is negative — it would invert the band
  'wide'   rc=1  time_precision 'wide' is not a number
  5.0e9    rc=1  time_precision 5000000000.0 is wider than the age of the Earth
  1.0e6    rc=0  (nothing said)
```

`src/graph.json` is unchanged — every destructive test ran against a copy.

```
python3 tools/validate_graph.py                 WARNINGS (0)   ERRORS (0)
python3 tools/check_no_local_paths.py --all     clean
python3 tools/build.py                          77/77 checks passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_