### PR TITLE
Strip the artifact head by category, not by spelling

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -20,6 +20,78 @@ def read(p):
         return f.read()
 
 
+# Elements that belong to a <head>. The artifact host supplies its own, so these
+# must not travel into the body it wraps, and "harmless if they do" is wrong:
+# Chromium honours a <base> wherever it sits, so a leaked one silently repoints
+# every relative URL on the host page, and a leaked <link rel="icon"> lands in
+# the DOM beside the host's own favicon.
+HEAD_ONLY = ("meta", "link", "base")
+
+# One token of the head prelude: a comment, a whole <title>...</title>, any other
+# tag, or the run of text between them. Anything that does not tokenise is a
+# shape this does not know, and is refused rather than guessed at.
+_PRELUDE_TOKEN = re.compile(
+    r"(?P<comment><!--.*?-->)"
+    r"|(?P<title><title\b[^>]*>.*?</title\s*>)"
+    r"|<(?P<name>[A-Za-z][\w:-]*)\b[^>]*>"
+    r"|(?P<text>[^<]+)",
+    re.S | re.I)
+
+
+def artifact_head(head, where="src/00_head.html"):
+    """The <head> content, minus the parts the artifact host supplies itself.
+
+    Keeps <title>, which the publisher reads, and the inlined <style>.
+
+    This used to be `re.sub(r'^<meta [^>]*/>\n', ...)`, which recognised the two
+    tags this file happened to have, spelled the way it happened to spell them.
+    Five other shapes went straight into the body: a <meta> without the trailing
+    slash, an indented one, an uppercase one, a <link>, a <base>.
+
+    Teaching the pattern those five shapes would fail the same way at the sixth,
+    so this refuses what it does not recognise instead of passing it through. A
+    build that stops is a bad minute; a <base> loose in someone else's page is
+    not something they would think to look for.
+    """
+    cut = re.search(r"<style\b", head, re.I)
+    if not cut:
+        sys.exit(f"FATAL: no <style> in {where}; the artifact build splits the head "
+                 "there and no longer knows where the prelude ends.")
+    prelude, styles = head[:cut.start()], head[cut.start():]
+
+    kept, pos = [], 0
+    for m in _PRELUDE_TOKEN.finditer(prelude):
+        if m.start() != pos:
+            sys.exit(f"FATAL: cannot parse the head prelude of {where} at character "
+                     f"{pos}: {prelude[pos:pos + 70]!r}")
+        pos = m.end()
+        if m.group("comment"):
+            continue
+        if m.group("title"):
+            kept.append(m.group(0).strip())
+            continue
+        if m.group("text") is not None:
+            if m.group("text").strip():
+                sys.exit(f"FATAL: stray text in the head prelude of {where}: "
+                         f"{m.group('text').strip()[:70]!r}")
+            continue
+        name = m.group("name").lower()
+        if name in HEAD_ONLY:
+            continue
+        sys.exit(f"FATAL: unrecognised <{name}> in the head prelude of {where}. The "
+                 f"artifact build keeps <title> and the inlined <style> and drops "
+                 f"{'/'.join(HEAD_ONLY)}; decide what artifact_head() should do with "
+                 f"<{name}> rather than letting it into the body by default.")
+    if pos != len(prelude):
+        sys.exit(f"FATAL: cannot parse the head prelude of {where} at character "
+                 f"{pos}: {prelude[pos:pos + 70]!r}")
+
+    if not kept:
+        sys.exit(f"FATAL: no <title> survived the head prelude of {where}; the "
+                 "artifact publisher reads it to name the page.")
+    return "\n".join(kept) + "\n" + styles
+
+
 def main():
     head = read(os.path.join(SRC, "00_head.html"))
     body = read(os.path.join(SRC, "10_body.html"))
@@ -59,10 +131,15 @@ def main():
     if re.search(r"</script", js, re.I):
         sys.exit("FATAL: a literal </script> inside the JS payload would close the tag early")
 
-    # The artifact host supplies its own <head>, so drop our meta tags there and
-    # keep only <title> (which the publisher reads) plus the inlined styles.
-    art = re.sub(r'^<meta [^>]*/>\n', '', head, flags=re.M) + "\n" + body + \
-        '\n<script>\n' + js + '\n</script>\n'
+    art_head = artifact_head(head)
+    # Belt and braces over the markup, and only the markup: the JS payload below
+    # is prose as much as code, and its comments discuss <html> and <body> in
+    # English. Widening this to the whole file would fail on a sentence.
+    stray = re.search(r"<\s*(meta|link|base)\b", art_head + body, re.I)
+    if stray:
+        sys.exit(f"FATAL: a head-only <{stray.group(1)}> reached artifact.html: "
+                 f"{(art_head + body)[stray.start():stray.start() + 70]!r}")
+    art = art_head + "\n" + body + '\n<script>\n' + js + '\n</script>\n'
     out_art = os.path.join(ROOT, "artifact.html")
     with open(out_art, "w", encoding="utf-8") as f:
         f.write(art)

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -1155,6 +1155,77 @@ def run_contrast(url, headed, report):
         browser.close()
 
 
+# ------------------------------------------------- the artifact head, offline
+# No browser needed: this is a property of what tools/build.py emits, and it is
+# the one gate that ran for a year without ever being exercised.
+def run_artifact(report):
+    """Prove that nothing head-only can reach the body of artifact.html.
+
+    The strip step used to be a pattern that matched the two tags src/00_head.html
+    happened to have. Five other shapes rode through it into the body, where a
+    <base> is honoured by Chromium and repoints every relative URL on the host
+    page. So the property under test is not "the current head is stripped" - that
+    passed the whole time - it is "a head-only tag cannot get through, whatever
+    it looks like": stripped, or the build stops. Never quietly kept.
+    """
+    sys.path.insert(0, HERE)
+    import build
+
+    tail = '<title>T</title>\n<style>b{color:red}</style>'
+    shapes = [
+        ("self-closed", '<meta charset="utf-8" />\n' + tail),
+        ("bare, no slash", '<meta charset="utf-8">\n' + tail),
+        ("indented", '  <meta charset="utf-8" />\n' + tail),
+        ("uppercase", '<META charset="utf-8" />\n' + tail),
+        ("attributes split over lines", '<meta name="viewport"\n   content="width=1" />\n' + tail),
+        ("link rel=icon", '<link rel="icon" href="data:," />\n' + tail),
+        ("base href", '<base href="/" />\n' + tail),
+        ("comment then meta", '<!-- c -->\n<meta charset="utf-8">\n' + tail),
+    ]
+    for label, head in shapes:
+        try:
+            out = build.artifact_head(head, where="<test>")
+            leaked = re.findall(r"<\s*(?:meta|link|base)\b[^>]*>", out, re.I | re.S)
+            report.check(f"head-only tag cannot reach the body: {label}",
+                         not leaked, "stripped" if not leaked else f"LEAKED {leaked}")
+        except SystemExit as e:
+            report.check(f"head-only tag cannot reach the body: {label}",
+                         True, f"refused: {str(e)[:48]}")
+
+    # <title> is what the publisher reads to name the page, so it has to survive
+    # the strip, and its absence has to stop the build rather than ship unnamed.
+    kept = build.artifact_head('<meta charset="utf-8">\n' + tail, where="<test>")
+    report.check("<title> survives the strip", "<title>T</title>" in kept, kept[:40])
+    try:
+        build.artifact_head('<meta charset="utf-8">\n<style>b{}</style>', where="<test>")
+        report.check("a head with no <title> stops the build", False, "it did not")
+    except SystemExit:
+        report.check("a head with no <title> stops the build", True)
+
+    # An unknown head element is refused, not passed through on the assumption
+    # that whatever it is must be safe in a body.
+    try:
+        build.artifact_head('<nosuchtag x="1">\n' + tail, where="<test>")
+        report.check("an unrecognised head element stops the build", False, "it did not")
+    except SystemExit:
+        report.check("an unrecognised head element stops the build", True)
+
+    # And the file actually on disk, which is what gets published.
+    art = os.path.join(ROOT, "artifact.html")
+    if os.path.exists(art):
+        text = open(art, encoding="utf-8").read()
+        # The markup only. The JS payload's comments discuss <html> and <body>
+        # in English, so scanning the whole file would flag prose.
+        markup = text.split("\n<script>\n")[0]
+        found = re.findall(r"<\s*(?:meta|link|base)\b[^>]*>", markup, re.I | re.S)
+        report.check("built artifact.html carries no head-only tags",
+                     not found, f"{len(found)} found" if found else "none")
+        report.check("built artifact.html has a <title> for the publisher",
+                     re.search(r"<title\b[^>]*>.+?</title>", text[:8192], re.S | re.I) is not None)
+        report.check("built artifact.html opens body-only, with no document wrapper",
+                     not re.match(r"\s*<\s*(!doctype|html)\b", text, re.I), repr(text[:34]))
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--url", default=None, help="test a deployed URL instead of the local build")
@@ -1174,6 +1245,7 @@ def main():
     print(f"smoke test: {url}")
     report = Report()
     try:
+        run_artifact(report)
         run(url, a.headed, report)
         run_mobile(url, a.headed, report)
         run_contrast(url, a.headed, report)


### PR DESCRIPTION
Closes #42.

`artifact.html` is built for a host that supplies its own `<head>`, so the head-only tags have to come out. That was one pattern — `^<meta [^>]*/>\n` — which recognised the two tags `src/00_head.html` happens to have, spelled the way it happens to spell them.

### What leaked

| shape | old | new |
|---|---|---|
| `<meta charset="utf-8" />` | stripped | stripped |
| `<meta charset="utf-8">` | **body** | stripped |
| `  <meta … />` indented | **body** | stripped |
| `<META … />` | **body** | stripped |
| attributes over two lines | stripped | stripped |
| `<link rel="icon" …>` | **body** | stripped |
| `<base href="/">` | **body** | stripped |
| anything unrecognised | **body** | build stops |

### Why it mattered

A head-only element in body position is not inert. In Chromium, against a host `<head>` that already had its own:

```
link[rel=icon] in DOM : ['…/host.ico', '…/leaked.ico']
meta[viewport] in DOM : ['width=1200', 'width=320']
<base> in body honored: http://leaked.example/rel.html
```

A leaked `<base>` is honoured wherever it sits and repoints every relative URL on the **host's** page. Nothing is leaking today — none of those tags exist in the head yet — so this is a trap rather than an active bug: adding a favicon, or writing `charset` without the trailing slash, would have leaked it silently.

### Approach

Teaching the pattern the five missing shapes fails the same way at the sixth. `artifact_head()` instead keeps `<title>` (the publisher reads it) and the inlined `<style>`, drops the head-only elements whatever their spelling, and **stops the build on anything it does not recognise** — the posture `tools/knowledge_time.py` already argues for.

Both guards are scoped to the markup, not the JS payload: its comments discuss `<html>` and `<body>` in English, and the wider check flagged that prose. That false positive is how the scope got chosen, and it's noted in the code.

### Verification

- 14 new checks in `run_artifact()`, browser-free. **9 of the 14 fail against the old implementation**; the 5 that pass are the cases it genuinely handled.
- End-to-end: each leaky tag put into the real `src/00_head.html`, rebuilt, confirmed absent from `artifact.html` and still present in `earth-x-time.html` (which has a real `<head>`); `<nosuchtag>` aborts with `FATAL: unrecognised <nosuchtag> in the head prelude`.
- `artifact.html`, `earth-x-time.html` and `index.html` rebuild byte-identical — no output change on the current head.
- Gates: `validate_graph.py` 0 errors, `check_no_local_paths.py` clean, smoke **77/77 → 91/91**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_