### PR TITLE
Anchor the path check on the token, not on the segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,19 @@ Obvious placeholders (`/home/you/…`) still pass. The hook is versioned in
 git config core.hooksPath .githooks
 ```
 
-Run it over everything already tracked with `--all`. All seven of its cases —
-four leak shapes, three that must not fire — are verified against a staged file
-and a real `git commit`, not against the checker called directly.
+Run it over everything already tracked with `--all`. Its cases — eight leak
+shapes, seven that must not fire, and the staged blob read both ways — are
+verified against a staged file and a real `git commit`, not against the checker
+called directly, and the smoke test drives those commits in a throwaway repo on
+every build.
+
+It matches an absolute path token and then looks for a home segment inside it,
+rather than matching the segment directly. The first version did the latter,
+with a lookbehind to keep `docs/home/index.md` from firing, and that lookbehind
+also required the segment to sit at the root: `/mnt/c/Users/name`,
+`/c/Users/name`, `/var/home/name` and `\\server\Users\name` all committed
+clean. Git Bash renders `C:\Users\name` as `/c/Users/name`, so the checker had
+been missing the shape of the exact incident it exists for.
 
 The knowledge-time bounds are declared once, in `src/20_core.js`, and
 `tools/knowledge_time.py` reads them out of it — nothing mirrors them by hand.

--- a/tools/check_no_local_paths.py
+++ b/tools/check_no_local_paths.py
@@ -32,16 +32,32 @@ import sys
 # hide forever. Fragments keep the scan total.
 _U = 'Users'
 _H = 'home'
-_SEP = '[\\\\/]'
 
-PATTERNS = [
-    # C:\Users\name  /  C:/Users/name  - any drive letter, any slash style
-    ('windows home', re.compile(r'[A-Za-z]:' + _SEP + r'+' + _U + _SEP + r'+([A-Za-z0-9_.\-]+)')),
-    # /Users/name - macOS
-    ('macos home',   re.compile(r'(?<![A-Za-z0-9_.\-])/' + _U + r'/([A-Za-z0-9_.\-]+)')),
-    # /home/name - linux
-    ('linux home',   re.compile(r'(?<![A-Za-z0-9_.\-])/' + _H + r'/([A-Za-z0-9_.\-]+)')),
-]
+# An absolute path token: something starting at a filesystem root - a leading
+# slash, a drive letter, or a UNC \\ - and running to whitespace or the
+# punctuation that ends a path in prose.
+#
+# The first version matched the home segment directly, with a lookbehind to keep
+# `docs/home/index.md` from firing. That lookbehind also required the segment to
+# sit at the root, so every mount-prefixed form went straight through: the
+# character before `/Users` in `/mnt/c/Users/name` is `c`, so WSL, Git Bash and
+# Silverblue paths all committed clean. Git Bash renders `C:\Users\name` as
+# `/c/Users/name`, which is to say the checker missed the shape of the exact
+# incident it exists for.
+#
+# Anchoring on the token instead keeps relative paths out - `docs/home/x` never
+# starts at a root, so it is never a token - without blinding the scan to a
+# prefix in front of the part that names somebody.
+_TOKEN = re.compile(r'(?:[A-Za-z]:|\\\\|(?<![A-Za-z0-9_.\-]))[\\/][^\s"\'`,;)\]}<>]*')
+_HOME = re.compile(r'[\\/](' + _U + '|' + _H + r')[\\/]+([A-Za-z0-9_.\-]+)')
+
+
+def _kind(token, segment):
+    if re.match(r'[A-Za-z]:', token):
+        return 'windows home'
+    if token.startswith('\\\\'):
+        return 'unc home'
+    return 'macos home' if segment == _U else 'linux home'
 
 # Obvious stand-ins in documentation. A real account name is the thing we are
 # stopping; `/home/you/project` in a README is fine and should stay writable.
@@ -97,11 +113,13 @@ def scan(path, raw):
         return  # not text; nothing readable to leak
 
     for lineno, line in enumerate(text.splitlines(), 1):
-        for kind, rx in PATTERNS:
-            for m in rx.finditer(line):
-                if m.group(1) in PLACEHOLDERS:
+        for tok in _TOKEN.finditer(line):
+            token = tok.group(0)
+            for m in _HOME.finditer(token):
+                if m.group(2) in PLACEHOLDERS:
                     continue
-                yield lineno, kind, m.group(0)
+                yield lineno, _kind(token, m.group(1)), token
+                break
 
 
 def main(argv):

--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -1226,6 +1226,108 @@ def run_artifact(report):
                      not re.match(r"\s*<\s*(!doctype|html)\b", text, re.I), repr(text[:34]))
 
 
+# --------------------------------------------- the pre-commit hook, for real
+# README.md claims these cases are verified "against a staged file and a real
+# git commit, not against the checker called directly", and that standard is
+# the whole point: the hook picks its own interpreter, git runs it from the
+# repo root, and the checker reads the staged blob rather than the file on
+# disk. Calling scan() in-process would exercise none of that. So this drives
+# real commits in a throwaway repo - never this one.
+def run_hook(report):
+    import shutil, subprocess, tempfile
+
+    env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_SYSTEM=os.devnull,
+               GIT_AUTHOR_NAME='t', GIT_AUTHOR_EMAIL='t@t',
+               GIT_COMMITTER_NAME='t', GIT_COMMITTER_EMAIL='t@t')
+    tmp = tempfile.mkdtemp(prefix='hook-check-')
+
+    def git(*a):
+        return subprocess.run(('git',) + a, cwd=tmp, env=env, capture_output=True, text=True)
+
+    def attempt(content, fname='p.md'):
+        """Stage content, try a real commit, return True if the commit landed."""
+        with open(os.path.join(tmp, fname), 'w', encoding='utf-8') as fh:
+            fh.write(content + '\n')
+        git('add', fname)
+        rc = git('commit', '-qm', 'case').returncode
+        git('reset', '-q', '--hard', 'HEAD')
+        git('clean', '-qfd')
+        return rc == 0
+
+    try:
+        os.makedirs(os.path.join(tmp, 'tools'))
+        os.makedirs(os.path.join(tmp, '.githooks'))
+        shutil.copy(os.path.join(ROOT, '.githooks', 'pre-commit'),
+                    os.path.join(tmp, '.githooks', 'pre-commit'))
+        shutil.copy(os.path.join(HERE, 'check_no_local_paths.py'),
+                    os.path.join(tmp, 'tools', 'check_no_local_paths.py'))
+        git('init', '-q', '.')
+        git('config', 'core.hooksPath', '.githooks')
+        git('add', '-A')
+        base = git('commit', '-qm', 'base')
+        if base.returncode:
+            report.check('scratch repo arms the hook', False, base.stderr.strip()[:90])
+            return
+        report.check('scratch repo arms the hook', True)
+
+        # Each of these names a real account and must never reach a public repo.
+        # The last four are the forms that used to commit clean: a mount prefix
+        # defeated the lookbehind the segment patterns relied on.
+        # Assembled from fragments for the same reason the checker's own patterns
+        # are: spelled out whole, these fixtures are themselves leaking paths in
+        # a tracked file, and --all would refuse this repo. Found the hard way -
+        # the first version of these checks failed its own --all check.
+        U, H, N = 'Us' + 'ers', 'ho' + 'me', 'jd' + 'oe'
+        for label, content in [
+            ('windows, backslash',   rf'see C:\{U}\{N}\proj\x.js'),
+            ('windows, forward',     f'see C:/{U}/{N}/proj/x.js'),
+            ('macOS',                f'see /{U}/{N}/proj/x.js'),
+            ('linux',                f'see /{H}/{N}/proj/x.js'),
+            ('WSL mount',            f'see /mnt/c/{U}/{N}/proj/x.js'),
+            ('Git Bash / MSYS',      f'see /c/{U}/{N}/proj/x.js'),
+            ('Silverblue /var/home', f'see /var/{H}/{N}/proj/x.js'),
+            ('UNC share',            rf'see \\fileserver\{U}\{N}\proj\x.js'),
+        ]:
+            report.check(f'hook blocks a real commit: {label}', not attempt(content))
+
+        # And these must not fire. A gate that cries wolf is one people learn to
+        # --no-verify past, which is worse than no gate at all.
+        for label, content in [
+            ('placeholder /home/you',    'clone to /home/you/earth-x-time'),
+            ('repo-relative citation',   'see src/00_head.html:336'),
+            ('relative docs/home path',  'see docs/home/index.md'),
+            ('relative assets/Users',    'see assets/Users/readme.md'),
+            ('/homebrew is not a home',  'installed under /homebrew/lib'),
+            ('bare /home directory',     'the /home directory'),
+            ('CI runner path',           'see /Users/runner/work/x'),
+        ]:
+            report.check(f'hook allows a real commit: {label}', attempt(content))
+
+        # The staged blob is what ships, not the file on disk.
+        q = os.path.join(tmp, 'q.md')
+        open(q, 'w', encoding='utf-8').write(f'see /{H}/{N}/x.js\n')
+        git('add', 'q.md')
+        open(q, 'w', encoding='utf-8').write('see src/x.js\n')   # cleaned after staging
+        rc = git('commit', '-qm', 'staged').returncode
+        git('reset', '-q', '--hard', 'HEAD'); git('clean', '-qfd')
+        report.check('hook reads the staged blob, not the worktree', rc != 0)
+
+        open(q, 'w', encoding='utf-8').write('clean\n')
+        git('add', 'q.md')
+        open(q, 'w', encoding='utf-8').write(f'see /{H}/{N}/x.js\n')   # never staged
+        rc = git('commit', '-qm', 'unstaged').returncode
+        git('reset', '-q', '--hard', 'HEAD'); git('clean', '-qfd')
+        report.check('hook ignores an unstaged worktree leak', rc == 0)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    # The repo as it stands has to pass its own gate in --all mode.
+    rc = subprocess.run([sys.executable, os.path.join(HERE, 'check_no_local_paths.py'), '--all'],
+                        cwd=ROOT, capture_output=True, text=True)
+    report.check('every tracked file passes --all', rc.returncode == 0,
+                 rc.stdout.strip().splitlines()[1].strip() if rc.returncode else 'clean')
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--url", default=None, help="test a deployed URL instead of the local build")
@@ -1246,6 +1348,7 @@ def main():
     report = Report()
     try:
         run_artifact(report)
+        run_hook(report)
         run(url, a.headed, report)
         run_mobile(url, a.headed, report)
         run_contrast(url, a.headed, report)


### PR DESCRIPTION
Closes #44.

`check_no_local_paths` matched `/Users/name` and `/home/name` directly, with a lookbehind so `docs/home/index.md` wouldn't fire. That lookbehind also required the segment to sit at the root, so any mount prefix defeated it — the character before `/Users` in `/mnt/c/Users/name` is `c`.

### What committed clean

| form | before | after |
|---|---|---|
| `C:\Users\name`, `C:/Users/name`, `/Users/name`, `/home/name` | blocked | blocked |
| `/mnt/c/Users/name` (WSL mount) | **clean** | blocked |
| `/c/Users/name` (Git Bash / MSYS) | **clean** | blocked |
| `/var/home/name` (Silverblue) | **clean** | blocked |
| `\\server\Users\name` (UNC) | **clean** | blocked |

The second row is the point. The incident this file exists for was a Windows agent handed absolute paths in its brief, and Git Bash renders `C:\Users\name` as `/c/Users/name`. The control was missing the shape of the thing it was written to catch.

### Why not just delete the lookbehind

Because it's load-bearing. Dropping it catches the four forms above and starts firing on `docs/home/index.md` and `assets/Users/readme.md` — and a gate that cries wolf is one people learn to `--no-verify` past, which is worse than the miss.

So the scan finds an **absolute path token** first — something starting at a root, a drive letter, or a UNC `\\` — and looks for a home segment inside it. A relative path never starts at a root, so it is never a token. 0 false positives across all 41 tracked files.

### Verification

19 checks driving **real `git commit`s in a throwaway repo** with `core.hooksPath` armed — never this one — rather than calling the checker in-process. That is the standard README.md already claimed for these cases; it just wasn't automated.

- **4 of the 19 fail against the old checker.** The other 15 are cases it genuinely handled, kept as regression cover in the other direction.
- Covers the staged-blob semantics both ways: a leak staged then cleaned in the worktree still blocks; a leak never staged does not.
- This PR's own commits went through the armed hook.

Two things found the hard way, both now recorded in the code:

- The fixtures are assembled from fragments, for the same reason the checker's own patterns are — spelled out whole they are leaking paths in a tracked file, and `--all` refused the repo. The first version of these checks failed its own `--all` check.
- README.md:200 claimed "all seven of its cases". It now says what is actually verified, and why the rule is shaped the way it is.

Gates: validator 0 warnings / 0 errors, `--all` clean, smoke **91/91 → 110/110**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98

---
_Generated by [Claude Code](https://claude.ai/code/session_0136QVmCF1cpo8zUrryNcw98)_